### PR TITLE
 Allow ENS controller to be snapshot space controller

### DIFF
--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -5,7 +5,6 @@ import { jsonParse } from '../helpers/utils';
 import log from '../helpers/log';
 
 const DEFAULT_NETWORK = process.env.DEFAULT_NETWORK || '1';
-const networkPath = DEFAULT_NETWORK === '1' ? '' : 'testnet/';
 
 export async function verify(body): Promise<any> {
   const msg = jsonParse(body.msg);
@@ -16,11 +15,8 @@ export async function verify(body): Promise<any> {
     return Promise.reject('wrong space format');
   }
 
-  const spaceUri = await snapshot.utils.getSpaceUri(msg.space, DEFAULT_NETWORK);
-  const spaceIdUri = encodeURIComponent(msg.space);
-  const isOwner =
-    spaceUri ===
-    `ipns://storage.snapshot.page/registry/${networkPath}${body.address}/${spaceIdUri}`;
+  const controller = await snapshot.utils.getSpaceController(msg.space, DEFAULT_NETWORK);
+  const isOwner = controller === body.address;
   const space = await getSpace(msg.space);
   const admins = (space?.admins || []).map(admin => admin.toLowerCase());
   const isAdmin = admins.includes(body.address.toLowerCase());

--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -16,15 +16,16 @@ export async function verify(body): Promise<any> {
   }
 
   const controller = await snapshot.utils.getSpaceController(msg.space, DEFAULT_NETWORK);
-  const isOwner = controller === body.address;
+  const isController = controller === body.address;
   const space = await getSpace(msg.space);
   const admins = (space?.admins || []).map(admin => admin.toLowerCase());
   const isAdmin = admins.includes(body.address.toLowerCase());
   const newAdmins = (msg.payload.admins || []).map(admin => admin.toLowerCase());
 
-  if (!isAdmin && !isOwner) return Promise.reject('not allowed');
+  if (!isAdmin && !isController) return Promise.reject('not allowed');
 
-  if (!isOwner && !isEqual(admins, newAdmins)) return Promise.reject('not allowed change admins');
+  if (!isController && !isEqual(admins, newAdmins))
+    return Promise.reject('not allowed change admins');
 }
 
 export async function action(body): Promise<void> {


### PR DESCRIPTION
Part of https://github.com/snapshot-labs/snapshot/issues/3472
---------------


**!IMPORTANT:**  So one thing to note is if the `snapshot` text record is IPFS or URL, we still allow new settings from the ENS controller, I think it should be fine

---------------
TODO:
- [x] Test it with mainnet and goerli ENS names
- [x] with different ENS controllers and snapshot existing controllers
- [x] Test with IPFS in snapshot text record

