### PR TITLE
Default score_state to pending instead of empty string

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -135,7 +135,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     app: kebabCase(msg.payload.app || ''),
     scores: JSON.stringify([]),
     scores_by_strategy: JSON.stringify([]),
-    scores_state: '',
+    scores_state: 'pending',
     scores_total: 0,
     scores_updated: 0,
     votes: 0,


### PR DESCRIPTION
An empty string in score_state is causing confusion, refer to https://github.com/snapshot-labs/snapshot/issues/3555#issuecomment-1457769239

so made it `pending` 