### PR TITLE
Add skale-delegation-weighted strategy to override list

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -56,7 +56,8 @@ export function hasStrategyOverride(strategies: any[]) {
     '"erc20-votes-with-override"',
     '"esd-delegation"',
     '"ocean-dao-brightid"',
-    '"orbs-network-delegation"'
+    '"orbs-network-delegation"',
+    '"skale-delegation-weighted"'
   ];
   const strategiesStr = JSON.stringify(strategies).toLowerCase();
   return keywords.some(keyword => strategiesStr.includes(`"name":${keyword}`));


### PR DESCRIPTION
Hello guys, we understand that strategy works a bit incorrect in current snapshot product.

In current strategy case `vp_state` should be `pending` till the end of proposal.

Only limited amount of addresses has `override` functionality so calculation of strategy for all addresses would take the same under 10 seconds.

And the amount of addresses which are be able to vote is comparably small (less than 1000)