### PR TITLE
Use proposal strategies if basic validation doesn't have strategies

### DIFF
--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -47,14 +47,19 @@ export async function verify(body): Promise<any> {
 
   if (proposal.validation?.name && proposal.validation.name !== 'any') {
     try {
-      const { validation } = proposal;
+      const {
+        validation: { name: validationName, params: validationParams }
+      } = proposal;
+      if (validationName === 'basic')
+        validationParams.strategies = validationParams.strategies ?? proposal.strategies;
+
       const validate = await snapshot.utils.validate(
-        validation.name,
+        validationName,
         body.address,
         msg.space,
         proposal.network,
         proposal.snapshot,
-        validation.params,
+        validationParams,
         {}
       );
       if (!validate) return Promise.reject('failed vote validation');


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot/pull/4053

Right now if we are not using custom strategies in basic validation, it fails, we should fallback to proposal strategies instead


How to test:
- Change your space settings to use basic validation and don't use any custom strategies
- Try to create a proposal and vote on it
- It will fail earlier, it should pass through with these changes