### PR TITLE
Add moonbeam-free-balance to override strategies to avoid outdated VP on existing votes

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -56,7 +56,8 @@ export function hasStrategyOverride(strategies: any[]) {
     '"erc20-votes-with-override"',
     '"esd-delegation"',
     '"ocean-dao-brightid"',
-    '"orbs-network-delegation"'
+    '"orbs-network-delegation"',
+    '"moonbeam-free-balance"'
   ];
   const strategiesStr = JSON.stringify(strategies).toLowerCase();
   return keywords.some(keyword => strategiesStr.includes(`"name":${keyword}`));


### PR DESCRIPTION
This is for voting power calculation issue of a proposal, will revert soon
