### PR TITLE
chore: add sentry to CI

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,0 +1,22 @@
+name: Create a Sentry release
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  sentry-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn build
+      - name: Sentry Release
+        uses: getsentry/action-release@v1.4.1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: snapshot-sequencer

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     "esModuleInterop": true,
     "strict": true,
     "noImplicitAny": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "moduleResolution": "Node",
+    "sourceMap": true,
+    "inlineSources": true,
+    "sourceRoot": "/"
   }
 }


### PR DESCRIPTION
- Create sourcemaps on build
- Upload the sourcemaps and create a Sentry release when deploying on main/master branch