### PR TITLE
chore: run prod app with node instead of ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "lint": "eslint . --ext .ts --fix",
     "dev": "nodemon src/index.ts",
-    "start": "ts-node src/index.ts"
+    "build": "tsc",
+    "start": "node build/src/index.js"
   },
   "eslintConfig": {
     "extends": "@snapshot-labs"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The current production app is run directly on typescript file with `ts-node`, instead of `node` on compiled js files.

This result in up to 10x more memory consumption.

## 💊 Fixes / Solution

- Run app on compiled js files

## 🚧 Changes

- Build js files
- Run app on js files

## 🛠️ Tests

- Run `yarn build`
- Run `yarn start`
- It should start the app