### PR TITLE
fix: allow space members to skip active proposal limit

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -170,7 +170,7 @@ export async function verify(body): Promise<any> {
 
     if (dayCount >= dayLimit || monthCount >= monthLimit)
       return Promise.reject('proposal limit reached');
-    if (activeProposalsByAuthor >= ACTIVE_PROPOSAL_BY_AUTHOR_LIMIT)
+    if (!isAuthorized && activeProposalsByAuthor >= ACTIVE_PROPOSAL_BY_AUTHOR_LIMIT)
       return Promise.reject('active proposal limit reached for author');
   } catch (e) {
     capture(e);


### PR DESCRIPTION
Add exception for members of a space (author, moderator or admin) to active proposal limit