### PR TITLE
hotfix: temporarily increase ecosystem daily proposal limit

### DIFF
--- a/src/helpers/limits.ts
+++ b/src/helpers/limits.ts
@@ -9,7 +9,7 @@ export const VERIFIED_SPACE_PROPOSAL_MONTH_LIMIT = 300;
 export const FLAGGED_SPACE_PROPOSAL_DAY_LIMIT = 5;
 export const FLAGGED_SPACE_PROPOSAL_MONTH_LIMIT = 50;
 
-export const ECOSYSTEM_SPACE_PROPOSAL_DAY_LIMIT = 100;
+export const ECOSYSTEM_SPACE_PROPOSAL_DAY_LIMIT = 105;
 export const ECOSYSTEM_SPACE_PROPOSAL_MONTH_LIMIT = 1000;
 export const ECOSYSTEM_SPACES = ['orbapp.eth', 'cakevote.eth', 'outcome.eth', 'polls.lenster.xyz'];
 


### PR DESCRIPTION
Temporary fix to allow a slightly higher daily proposal limit for ecosystem spaces. To be reverted soon.