### PR TITLE
fix: pull flagged items from laser database

### DIFF
--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -6,12 +6,18 @@ const moderationURL = 'https://sh5.co/api/moderation';
 
 export let flaggedSpaces: Array<string> = [];
 export let flaggedIps: Array<string> = [];
+export let flaggedAddresses: Array<string> = [];
+export let flaggedProposalTitleKeywords: Array<string> = [];
+export let flaggedProposalBodyKeywords: Array<string> = [];
 export let verifiedSpaces: Array<string> = [];
 
 async function loadModerationData() {
   const res = await snapshot.utils.getJSON(moderationURL);
   flaggedSpaces = res?.flaggedSpaces;
   flaggedIps = res?.flaggedIps;
+  flaggedAddresses = res?.flaggedAddresses;
+  flaggedProposalTitleKeywords = res?.flaggedProposalTitleKeywords;
+  flaggedProposalBodyKeywords = res?.flaggedProposalBodyKeywords;
   verifiedSpaces = res?.verifiedSpaces;
 }
 

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -8,6 +8,11 @@ import { getSpace } from '../helpers/actions';
 import log from '../helpers/log';
 import { ACTIVE_PROPOSAL_BY_AUTHOR_LIMIT, getSpaceLimits } from '../helpers/limits';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import {
+  flaggedAddresses,
+  flaggedProposalTitleKeywords,
+  flaggedProposalBodyKeywords
+} from '../helpers/moderation';
 
 const network = process.env.NETWORK || 'testnet';
 
@@ -89,20 +94,12 @@ export async function verify(body): Promise<any> {
     if (msg.payload.type !== space.voting.type) return Promise.reject('invalid voting type');
   }
 
-  // Temporary fix to block proposal from scammer
-  const blockedAddress = [
-    '0x2c8829427ce20d57614c461f5b2e9ada53a3dd96',
-    '0x30323cf33a62651460405e3c1984835094168a60',
-    '0xd48b7d0b0a9af29aaebda2c6f27abc0b821341de'
-  ];
-  const blockedKeywords = ['✅', 'drop claim'];
-  const blockedKeywordsInBody = ['claim airdrop here'];
   const proposalNameLC = msg.payload.name.toLowerCase();
   const proposalBodyLC = msg.payload.body.toLowerCase();
   if (
-    blockedAddress.includes(addressLC) ||
-    blockedKeywordsInBody.some(keyword => proposalBodyLC.includes(keyword)) ||
-    blockedKeywords.some(keyword => proposalNameLC.includes(keyword))
+    flaggedAddresses.includes(addressLC) ||
+    flaggedProposalBodyKeywords.some(keyword => proposalBodyLC.includes(keyword)) ||
+    flaggedProposalTitleKeywords.some(keyword => proposalNameLC.includes(keyword))
   )
     return Promise.reject('scam proposal detected, contact support');
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

There's a few hardcoded list of flagged items:

https://github.com/snapshot-labs/snapshot-sequencer/blob/13dc5b314b69ff4829e67ab6815ef537cdf1374e/src/writer/proposal.ts#L93-L99

## 💊 Fixes / Solution

These items have already been migrated to laser/sidekick, and can already been pulled from sidekick

## 🚧 Changes

- Fetch the list from sidekick

## 🛠️ Tests

