### PR TITLE
chore: upgrade shutter dependency to latest stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ethersproject/hash": "^5.5.0",
     "@ethersproject/providers": "^5.6.8",
     "@ethersproject/wallet": "^5.6.2",
-    "@shutter-network/shutter-crypto": "^0.1.0-beta.3",
+    "@shutter-network/shutter-crypto": "^1.0.0",
     "@snapshot-labs/pineapple": "^0.1.0-beta.1",
     "@snapshot-labs/snapshot-sentry": "^1.1.0",
     "@snapshot-labs/snapshot.js": "^0.4.107",

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,10 +614,10 @@
     "@sentry/types" "7.60.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@shutter-network/shutter-crypto@^0.1.0-beta.3":
-  version "0.1.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@shutter-network/shutter-crypto/-/shutter-crypto-0.1.0-beta.3.tgz#0ec7a3beab87aed15363349d240dfdff8d462012"
-  integrity sha512-kX9gOODp/4HqRubM7Hx4bb36yuVxIB/FOb4CfhB3gGWO5H2u7i0EnvrdJzsYXtDSrELXv7ay5Ly9k6X2fAk1jA==
+"@shutter-network/shutter-crypto@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@shutter-network/shutter-crypto/-/shutter-crypto-1.0.1.tgz#b26ac82ecfe3aadaa261581d58f625c9b75e3699"
+  integrity sha512-bA8uFUkjBaec0ui8za7cEEvspcUTi5DdsO/U8mq2MkgdVu+JRoNuQOhS0hVbh77FXOhXVIZXNf6iHxRIk/IjJQ==
   dependencies:
     browser-or-node "^2.0.0"
 


### PR DESCRIPTION
Previous beta version of shutter was conflicting with Sentry package, and crashes.

See https://github.com/shutter-network/rolling-shutter/issues/390

The issue has now been fixed from shutter side, and they released a new stable 1.0.0 version.