### PR TITLE
chore: fix wrong branch name in workflow

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -3,7 +3,7 @@ name: Create a Sentry release
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
 
 jobs:
   create-sentry-release:


### PR DESCRIPTION
The workflow was set to run on `main` instead of `master`