### PR TITLE
chore: do not send user input errors to Sentry

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -3,7 +3,7 @@ name: Create a Sentry release
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
 
 jobs:
   create-sentry-release:

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,6 @@ router.post('/', async (req, res) => {
     const result = await typedData(req);
     return res.json(result);
   } catch (e) {
-    capture(e);
     log.warn(`[ingestor] msg validation failed (typed data)`, e);
     return sendError(res, e);
   }

--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -25,7 +25,6 @@ export default async function ingestor(req) {
 
   const schemaIsValid = snapshot.utils.validateSchema(envelope, body);
   if (schemaIsValid !== true) {
-    capture(schemaIsValid);
     log.warn(`[ingestor] Wrong envelope format ${JSON.stringify(schemaIsValid)}`);
     return Promise.reject('wrong envelope format');
   }

--- a/src/writer/profile.ts
+++ b/src/writer/profile.ts
@@ -3,13 +3,11 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import db from '../helpers/mysql';
 import { jsonParse } from '../helpers/utils';
 import log from '../helpers/log';
-import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export async function verify(body): Promise<any> {
   const profile = jsonParse(body.profile, {});
   const schemaIsValid = snapshot.utils.validateSchema(snapshot.schemas.profile, profile);
   if (schemaIsValid !== true) {
-    capture(schemaIsValid);
     log.warn(`[writer] Wrong profile format ${JSON.stringify(schemaIsValid)}`);
     return Promise.reject('wrong profile format');
   }

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -46,7 +46,6 @@ export async function verify(body): Promise<any> {
 
   const schemaIsValid = snapshot.utils.validateSchema(snapshot.schemas.proposal, msg.payload);
   if (schemaIsValid !== true) {
-    capture(schemaIsValid);
     log.warn('[writer] Wrong proposal format', schemaIsValid);
     return Promise.reject('wrong proposal format');
   }

--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -10,7 +10,6 @@ export async function verify(body): Promise<any> {
 
   const schemaIsValid = snapshot.utils.validateSchema(snapshot.schemas.space, msg.payload);
   if (schemaIsValid !== true) {
-    capture(schemaIsValid);
     log.warn('[writer] Wrong space format', schemaIsValid);
     return Promise.reject('wrong space format');
   }

--- a/src/writer/statement.ts
+++ b/src/writer/statement.ts
@@ -3,13 +3,11 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import db from '../helpers/mysql';
 import { jsonParse } from '../helpers/utils';
 import log from '../helpers/log';
-import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export async function verify(body): Promise<any> {
   const msg = jsonParse(body.msg, {});
   const schemaIsValid = snapshot.utils.validateSchema(snapshot.schemas.statement, msg.payload);
   if (schemaIsValid !== true) {
-    capture(schemaIsValid);
     log.warn(`[writer] Wrong statement format ${JSON.stringify(schemaIsValid)}`);
     return Promise.reject('wrong statement format');
   }

--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -20,7 +20,6 @@ export async function verify(body): Promise<any> {
 
   const schemaIsValid = snapshot.utils.validateSchema(snapshot.schemas.vote, msg.payload);
   if (schemaIsValid !== true) {
-    capture(schemaIsValid);
     log.warn('[writer] Wrong vote format', schemaIsValid);
     return Promise.reject('wrong vote format');
   }


### PR DESCRIPTION
The initial sentry installation commit was only putting a `capture()` in all catch blocks.

After monitoring the errors, there's a few cases where a try/catch is being used to catch invalid user input. 

This PR is removing a few `capture()` calls, which were logging user invalid input as errors, which should be filtered out as they're not code related errors.