### PR TITLE
chore: allow update notification for all package from organization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "daily"
     allow:
       # Allow updates for snapshot.js only
-      - dependency-name: "@snapshot-labs/snapshot.js"
+      - dependency-name: "@snapshot-labs/*"


### PR DESCRIPTION
Relax dependabot rules to include all package from @snapshot-labs (to also include pineapple, config, metrics, and sentry)