### PR TITLE
chore: instrument rate limited request

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,14 +1,33 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
 import { Express } from 'express';
 
+const whitelistedPath = [/^\/$/, /^\/scores\/.+$/, /^\/spaces\/.+\/poke$/];
+
+const rateLimitedRequestsCount = new client.Counter({
+  name: 'http_requests_by_rate_limit_count',
+  help: 'Total number of requests, by rate limit status',
+  labelNames: ['rate_limited']
+});
+
+function instrumentRateLimitedRequests(req, res, next) {
+  res.on('finish', () => {
+    if (whitelistedPath.some(path => path.test(req.path))) {
+      rateLimitedRequestsCount.inc({ rate_limited: res.statusCode === 429 ? 1 : 0 });
+    }
+  });
+
+  next();
+}
+
 export default function initMetrics(app: Express) {
   init(app, {
     normalizedPath: [
       ['/scores/.+', '/scores/#id'],
       ['/spaces/.+/poke', '/spaces/#key/poke']
     ],
-    whitelistedPath: [/^\/$/, /^\/scores\/.+$/, /^\/spaces\/.+\/poke$/]
+    whitelistedPath
   });
+  app.use(instrumentRateLimitedRequests);
 }
 
 export const timeIngestorProcess = new client.Histogram({


### PR DESCRIPTION
This PR add metrics to track the count of rate limited requests

This is a copy/paste of the same code already on hub and score-api