### PR TITLE
chore: update capture signature

### DIFF
--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -12,7 +12,7 @@ export async function getSpaceENS(id) {
     try {
       space = await snapshot.utils.getJSON(uri);
     } catch (e) {
-      capture(e, { contexts: { input: { id, uri } } });
+      capture(e, { id, uri });
       log.warn(`[ens] getSpaceENS failed ${id}, ${JSON.stringify(e)}`);
     }
   }

--- a/src/writer/delete-space.ts
+++ b/src/writer/delete-space.ts
@@ -26,7 +26,7 @@ export async function action(body): Promise<void> {
   try {
     await markSpaceAsDeleted(space);
   } catch (e) {
-    capture(e, { contexts: { input: { space } } });
+    capture(e, { space });
     log.error('[writer] Failed to store settings', space, e);
     return Promise.reject('failed store settings');
   }

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -142,7 +142,7 @@ export async function verify(body): Promise<any> {
 
       if (!isValid) return Promise.reject('validation failed');
     } catch (e) {
-      capture(e, { contexts: { input: { space: msg.space, address: body.address } } });
+      capture(e, { space: msg.space, address: body.address });
       log.warn(
         `[writer] Failed to check proposal validation, ${msg.space}, ${
           body.address

--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -38,7 +38,7 @@ export async function action(body): Promise<void> {
   try {
     await addOrUpdateSpace(space, msg.payload);
   } catch (e) {
-    capture(e, { contexts: { input: { space } } });
+    capture(e, { space });
     log.error('[writer] Failed to store settings', msg.space, e);
     return Promise.reject('failed store settings');
   }


### PR DESCRIPTION
This PR updates the `capture` call to use the shorter signature, added in  https://github.com/snapshot-labs/snapshot-sentry/releases/tag/v1.3.0