### PR TITLE
chore: capture JSON-RPC error

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -141,8 +141,20 @@ export async function verify(body): Promise<any> {
       }
 
       if (!isValid) return Promise.reject('validation failed');
-    } catch (e) {
-      capture(e, { contexts: { input: { space: msg.space, address: body.address } } });
+    } catch (e: any) {
+      if (e instanceof Error) {
+        capture(e, { space: msg.space, address: body.address });
+      } else {
+        capture(new Error('Validation failed'), {
+          contexts: {
+            validationError: e,
+            input: {
+              space: msg.space,
+              address: body.address
+            }
+          }
+        });
+      }
       log.warn(
         `[writer] Failed to check proposal validation, ${msg.space}, ${
           body.address


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

`capture` is expecting an error object, whereas the snapshot.js SDK is returning a JSON-RPC  object on some occasion, resulting on this kind of generic error: `Non-Error exception captured with keys: code, data, message` (https://snapshot-labs.sentry.io/issues/4452136608/?project=4505606761152512&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=8)

## 💊 Fixes / Solution

Convert the JSON-RPC object to an error before sending it to sentry, with a better descriptive error message, and contexts.

## 🚧 Changes

- Convert and format the JSON-RPC object as an error, before sending to Sentry

## 🛠️ Tests

- N/A