### PR TITLE
chore: upgrade snapshot-sentry to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@shutter-network/shutter-crypto": "^1.0.0",
     "@snapshot-labs/pineapple": "^0.2.0",
     "@snapshot-labs/snapshot-metrics": "^1.0.0",
-    "@snapshot-labs/snapshot-sentry": "^1.3.0",
+    "@snapshot-labs/snapshot-sentry": "^1.4.0",
     "@snapshot-labs/snapshot.js": "^0.5.8",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,10 +1273,10 @@
     express-prom-bundle "^6.6.0"
     prom-client "^14.2.0"
 
-"@snapshot-labs/snapshot-sentry@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.3.0.tgz#9822d62b9a8918c70a09167da7b36ff43b9edba0"
-  integrity sha512-Qy+uLwsLhlRjx8MSbVU46tYVbiA5fIp6i1bgyab5pHwqsBaP93sjQIBetfGzeWxmmUXI8cS4lUOCc/x0HXEEGg==
+"@snapshot-labs/snapshot-sentry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.4.0.tgz#77933c2d8a32bb1b8daa05fec78ea73f8b78258d"
+  integrity sha512-261ZJGQ1rsSnAqsPrED1Hn2CoRFLtGla2WfnhqddcfYfYgEx2hsxUGs0jpSBCSfY/AsfK1+MgsoIXOFWXu74qQ==
   dependencies:
     "@sentry/node" "^7.60.1"
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

`capture` is expecting an error object, whereas the snapshot.js SDK is returning a JSON-RPC  object on some occasion, resulting on this kind of generic error: `Non-Error exception captured with keys: code, data, message` (https://snapshot-labs.sentry.io/issues/4452136608/?project=4505606761152512&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=8)

## 💊 Fixes / Solution

Convert the JSON-RPC object to an error before sending it to sentry, with a better descriptive error message, and contexts.

## 🚧 Changes

- Upgrade snapshot-sentry package to 1.4.0, which is handling JSON-RPC object

## 🛠️ Tests

- N/A