### PR TITLE
fix: update to pineapple@1

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,5 +19,6 @@ export default {
   moduleFileExtensions: ['js', 'ts'],
   fakeTimers: {
     enableGlobally: true
-  }
+  },
+  verbose: true
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ethersproject/strings": "^5.7.0",
     "@ethersproject/wallet": "^5.6.2",
     "@shutter-network/shutter-crypto": "^1.0.0",
-    "@snapshot-labs/pineapple": "^0.2.0",
+    "@snapshot-labs/pineapple": "^1.0.1",
     "@snapshot-labs/snapshot-metrics": "^1.2.0",
     "@snapshot-labs/snapshot-sentry": "^1.4.0",
     "@snapshot-labs/snapshot.js": "^0.5.8",

--- a/test/integration/ingestor.test.ts
+++ b/test/integration/ingestor.test.ts
@@ -180,7 +180,7 @@ describe('ingestor', () => {
 
   it('rejects when IPFS pinning fail', async () => {
     mockPin.mockImplementationOnce(() => {
-      throw new Error();
+      return Promise.reject('');
     });
 
     await expect(ingestor(proposalRequest)).rejects.toMatch('pin');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,12 +1253,12 @@
   dependencies:
     "@snapshot-labs/eslint-config-base" "^0.1.0-beta.11"
 
-"@snapshot-labs/pineapple@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/pineapple/-/pineapple-0.2.0.tgz#b7005baa1ee6b56d446668972fe52b420fa12357"
-  integrity sha512-qphtrQQVYyDVbviak2Zluuh73SWaQFnG9+K/oLsSKSLg0TQmrY8aYxxjDipOTtX0Oyz7+OWYaADZ37gVyp/JxA==
+"@snapshot-labs/pineapple@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/pineapple/-/pineapple-1.0.1.tgz#fbf4696bdf8be06cc45f722e1109c9dac899f02e"
+  integrity sha512-bBazy4gsRYjhZqvK3ZDmmS4YOsttPFBEa5Loz2lT/rqICjm1gON72t4IoTKnBCqx6zwxBhQs8UsWy9ugD8AYrA==
   dependencies:
-    cross-fetch "^3.1.5"
+    ofetch "^1.3.3"
 
 "@snapshot-labs/prettier-config@^0.1.0-beta.7":
   version "0.1.0-beta.7"
@@ -2189,7 +2189,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.1.5, cross-fetch@^3.1.6:
+cross-fetch@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
   integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
@@ -2272,6 +2272,11 @@ depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+destr@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.1.tgz#2fc7bddc256fed1183e03f8d148391dde4023cb2"
+  integrity sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==
 
 destroy@1.2.0:
   version "1.2.0"
@@ -4200,6 +4205,11 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+node-fetch-native@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.4.0.tgz#fbe8ac033cb6aa44bd106b5e4fd2b6277ba70fa1"
+  integrity sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==
+
 node-fetch@^2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
@@ -4316,6 +4326,15 @@ object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+ofetch@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.3.3.tgz#588cb806a28e5c66c2c47dd8994f9059a036d8c0"
+  integrity sha512-s1ZCMmQWXy4b5K/TW9i/DtiN8Ku+xCiHcjQ6/J/nDdssirrQNOoB165Zu8EqLMA2lln1JUth9a0aW9Ap2ctrUg==
+  dependencies:
+    destr "^2.0.1"
+    node-fetch-native "^1.4.0"
+    ufo "^1.3.0"
 
 on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
@@ -5307,6 +5326,11 @@ typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+ufo@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.0.tgz#c92f8ac209daff607c57bbd75029e190930a0019"
+  integrity sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR update pineapple.js to v1, which enable kepp alive connections