### PR TITLE
chore: fix pineapple error capture

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -182,8 +182,8 @@ export default async function ingestor(req) {
         pin(ipfsBody, process.env.PINEAPPLE_URL),
         issueReceipt(body.sig)
       ]);
-    } catch (e) {
-      capture(e);
+    } catch (e: any) {
+      capture(e.error || e);
       return Promise.reject('pinning failed');
     }
     const ipfs = pinned.cid;


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

New pineapple lib is returning the json-rpc error object nested in a `error` key, making the sentry automatic json-rpc parsing failing.

capture expect `{ code: '', message: ''}`, while pineapple is returning `{ error: { code: '', message: ''} }`.

## 💊 Fixes / Solution

When `error` property exist, capture it's value.

## 🚧 Changes

- capture the content of the `error` property when available

## 🛠️ Tests

- N/A