### PR TITLE
fix: ignore 429 from ingestor process error instrumentation

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -55,7 +55,7 @@ const ingestorInstrumentation = (req, res, next) => {
   const oldJson = res.json;
 
   res.json = body => {
-    if (res.statusCode >= 400 && res.statusCode < 500 && body) {
+    if (res.statusCode >= 400 && res.statusCode < 500 && res.statusCode !== 429 && body) {
       endTimer({
         type: Object.keys(req.body?.data?.types || {})[0],
         error: body.error_description


### PR DESCRIPTION
This PR exclude 429 errors from instrumented errors in the ingestor workflow.

429 errors are skewing the results, and creating a lot of noise