### PR TITLE
chore: upgrade sentry package to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@shutter-network/shutter-crypto": "^1.0.0",
     "@snapshot-labs/pineapple": "^1.0.1",
     "@snapshot-labs/snapshot-metrics": "^1.3.0",
-    "@snapshot-labs/snapshot-sentry": "^1.4.0",
+    "@snapshot-labs/snapshot-sentry": "^1.5.0",
     "@snapshot-labs/snapshot.js": "^0.6.0",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     node-fetch "^2.7.0"
     prom-client "^14.2.0"
 
-"@snapshot-labs/snapshot-sentry@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.4.0.tgz#77933c2d8a32bb1b8daa05fec78ea73f8b78258d"
-  integrity sha512-261ZJGQ1rsSnAqsPrED1Hn2CoRFLtGla2WfnhqddcfYfYgEx2hsxUGs0jpSBCSfY/AsfK1+MgsoIXOFWXu74qQ==
+"@snapshot-labs/snapshot-sentry@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.5.0.tgz#dbcd078041863790fe1a02ffb61e25cfd49a5436"
+  integrity sha512-j21gIXpY6uOY1GrJ+4zgyySBzbxX5NfvcR+10/rlbR0TBq7O3fjwI5iW1jOqCZu+GA9B406HaXyyv1I2v8CuaA==
   dependencies:
     "@sentry/node" "^7.60.1"
 


### PR DESCRIPTION
This PR upgrade the @snapshot-labs/snapshot-sentry package to 1.5.0, to fix the `Non-Error exception captured with keys: error` error on Sentry (e.g. https://snapshot-labs.sentry.io/issues/4366128821/?project=4505606761152512&query=is%3Aunresolved&referrer=issue-stream&stream_index=2)