### PR TITLE
chore: customize the sourcemaps location path

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -11,3 +11,4 @@ jobs:
     secrets: inherit
     with:
       project: snapshot-sequencer
+      sourcemaps: './build'


### PR DESCRIPTION
Customize the sourcemaps location when uploading to Sentry