### PR TITLE
fix: use `fetch` to load remote JSON data

### DIFF
--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -1,6 +1,7 @@
 import snapshot from '@snapshot-labs/snapshot.js';
-import log from './log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import fetch from 'cross-fetch';
+import log from './log';
 import db from './mysql';
 
 const sidekickURL = process.env.SIDEKICK_URL || 'https://sh5.co';
@@ -13,14 +14,24 @@ export let flaggedProposalTitleKeywords: Array<string> = [];
 export let flaggedProposalBodyKeywords: Array<string> = [];
 export let verifiedSpaces: Array<string> = [];
 
-async function loadModerationData() {
-  const res = await snapshot.utils.getJSON(moderationURL);
-  flaggedSpaces = res?.flaggedSpaces;
-  flaggedIps = res?.flaggedIps;
-  flaggedAddresses = res?.flaggedAddresses;
-  flaggedProposalTitleKeywords = res?.flaggedProposalTitleKeywords;
-  flaggedProposalBodyKeywords = res?.flaggedProposalBodyKeywords;
-  verifiedSpaces = res?.verifiedSpaces;
+export async function loadModerationData(url = moderationURL) {
+  try {
+    const res = await fetch(url);
+    const body = await res.json();
+
+    if (body.error) {
+      return;
+    }
+
+    flaggedSpaces = body.flaggedSpaces;
+    flaggedIps = body.flaggedIps;
+    flaggedAddresses = body.flaggedAddresses;
+    flaggedProposalTitleKeywords = body.flaggedProposalTitleKeywords;
+    flaggedProposalBodyKeywords = body.flaggedProposalBodyKeywords;
+    verifiedSpaces = body.verifiedSpaces;
+  } catch (e: any) {
+    capture(e);
+  }
 }
 
 export default async function run() {

--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -20,6 +20,7 @@ export async function loadModerationData(url = moderationURL) {
     const body = await res.json();
 
     if (body.error) {
+      capture(body.error);
       return;
     }
 

--- a/test/integration/helpers/moderation.test.ts
+++ b/test/integration/helpers/moderation.test.ts
@@ -1,0 +1,40 @@
+import {
+  loadModerationData,
+  flaggedSpaces,
+  flaggedIps,
+  flaggedAddresses,
+  flaggedProposalTitleKeywords,
+  flaggedProposalBodyKeywords,
+  verifiedSpaces
+} from '../../../src/helpers/moderation';
+
+describe('moderation', () => {
+  describe('loadModerationData()', () => {
+    describe('on success', () => {
+      it('loads moderation data from sidekick', async () => {
+        await loadModerationData();
+
+        expect(flaggedSpaces).not.toHaveLength(0);
+        expect(flaggedIps).not.toHaveLength(0);
+        expect(flaggedAddresses).not.toHaveLength(0);
+        expect(flaggedProposalTitleKeywords).not.toHaveLength(0);
+        expect(flaggedProposalBodyKeywords).not.toHaveLength(0);
+        expect(verifiedSpaces).not.toHaveLength(0);
+      });
+    });
+
+    describe('on error', () => {
+      it.each([
+        ['no response', 'http://localhost:9999'],
+        ['empty url', ''],
+        ['invalid hostname', 'test']
+      ])('returns nothing on network error (%s)', (title, url) => {
+        expect(loadModerationData(url)).resolves.toBeUndefined();
+      });
+
+      it('returns nothing on not-json response', () => {
+        expect(loadModerationData('https://snapshot.org')).resolves.toBeUndefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The retrieving of the moderation list from sidekick is done through the `getJSON` utils from snapshot.js.

While this is convenient, it complicates the error handling and tracking.

## 💊 Fixes / Solution

Move the JSON fetching to a full-fledged `fetch` function call.

This allow rescuing, handling, and tracking of different kind of errors. This will also allow use of keep-alive, timeout and retry connections in a future PR.

## 🚧 Changes

- Migrate from `getJSON` to `fetch` to retrieve moderation data
- Handle error when fetching JSON data is failing
- Add tests

## 🛠️ Tests

- Trust the tests