### PR TITLE
feat(flag): trigger verified/flagged field on set opposite data

### DIFF
--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -44,13 +44,13 @@ export function flagEntity({ type, action, value }) {
   let query;
   switch (`${type}-${action}`) {
     case 'space-flag':
-      query = `UPDATE spaces SET flagged = 1 WHERE id = ? LIMIT 1`;
+      query = `UPDATE spaces SET flagged = 1, verified = 0 WHERE id = ? LIMIT 1`;
       break;
     case 'space-verify':
       query = `UPDATE spaces SET verified = 1, flagged = 0 WHERE id = ? LIMIT 1`;
       break;
     case 'proposal-flag':
-      query = `UPDATE proposals SET flagged = 1, verified = 0 WHERE id = ? LIMIT 1`;
+      query = `UPDATE proposals SET flagged = 1 WHERE id = ? LIMIT 1`;
       break;
   }
 

--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -47,10 +47,10 @@ export function flagEntity({ type, action, value }) {
       query = `UPDATE spaces SET flagged = 1 WHERE id = ? LIMIT 1`;
       break;
     case 'space-verify':
-      query = `UPDATE spaces SET verified = 1 WHERE id = ? LIMIT 1`;
+      query = `UPDATE spaces SET verified = 1, flagged=0 WHERE id = ? LIMIT 1`;
       break;
     case 'proposal-flag':
-      query = `UPDATE proposals SET flagged = 1 WHERE id = ? LIMIT 1`;
+      query = `UPDATE proposals SET flagged = 1, verified=0 WHERE id = ? LIMIT 1`;
       break;
   }
 

--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -50,7 +50,7 @@ export function flagEntity({ type, action, value }) {
       query = `UPDATE spaces SET verified = 1, flagged = 0 WHERE id = ? LIMIT 1`;
       break;
     case 'proposal-flag':
-      query = `UPDATE proposals SET flagged = 1, verified=0 WHERE id = ? LIMIT 1`;
+      query = `UPDATE proposals SET flagged = 1, verified = 0 WHERE id = ? LIMIT 1`;
       break;
   }
 

--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -47,7 +47,7 @@ export function flagEntity({ type, action, value }) {
       query = `UPDATE spaces SET flagged = 1 WHERE id = ? LIMIT 1`;
       break;
     case 'space-verify':
-      query = `UPDATE spaces SET verified = 1, flagged=0 WHERE id = ? LIMIT 1`;
+      query = `UPDATE spaces SET verified = 1, flagged = 0 WHERE id = ? LIMIT 1`;
       break;
     case 'proposal-flag':
       query = `UPDATE proposals SET flagged = 1, verified=0 WHERE id = ? LIMIT 1`;


### PR DESCRIPTION
Changed the flow of flagging/verifying spaces:
- if space marked `verified=1` then the `flagged=0`
- if space marked `flagged=1` then the `verified=0`