### PR TITLE
feat: Use only sequencer DB for messages

### DIFF
--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -1,9 +1,8 @@
-import { default as hubDB, sequencerDB } from './mysql';
+import { sequencerDB } from './mysql';
 
 export async function storeMsg(id, ipfs, address, version, timestamp, space, type, sig, receipt) {
   const query = 'INSERT INTO messages SET ?';
-  // TODO: remove this once migration is done
-  const result = await hubDB.queryAsync(query, [
+  await sequencerDB.queryAsync(query, [
     {
       id,
       ipfs,
@@ -16,23 +15,6 @@ export async function storeMsg(id, ipfs, address, version, timestamp, space, typ
       receipt
     }
   ]);
-  if (result.insertId) {
-    // TODO: remove IGNORE once migration is done
-    await sequencerDB.queryAsync('INSERT IGNORE INTO messages SET ?', [
-      {
-        id,
-        mci: result.insertId,
-        ipfs,
-        address,
-        version,
-        timestamp,
-        space,
-        type,
-        sig,
-        receipt
-      }
-    ]);
-  }
 }
 
 export async function doesMessageExist(id: string): Promise<boolean> {

--- a/test/integration/helpers/highlight.test.ts
+++ b/test/integration/helpers/highlight.test.ts
@@ -1,5 +1,5 @@
 import { doesMessageExist, storeMsg } from '../../../src/helpers/highlight';
-import db from '../../../src/helpers/mysql';
+import db, { sequencerDB } from '../../../src/helpers/mysql';
 
 describe('highlight', () => {
   describe('doesMessageExist()', () => {
@@ -14,7 +14,8 @@ describe('highlight', () => {
         'DELETE from snapshot_sequencer_test.messages where id = ?',
         'test-exists'
       );
-      return db.endAsync();
+      await db.endAsync();
+      await sequencerDB.endAsync();
     });
 
     it('returns false when message does not exist yet', async () => {

--- a/test/integration/ingestor.test.ts
+++ b/test/integration/ingestor.test.ts
@@ -99,7 +99,8 @@ describe('ingestor', () => {
   afterAll(async () => {
     await db.queryAsync('DELETE FROM snapshot_sequencer_test.proposals;');
     await db.queryAsync('DELETE FROM snapshot_sequencer_test.messages;');
-    return await db.endAsync();
+    await db.endAsync();
+    await sequencerDB.endAsync();
   });
 
   it('rejects when the submitter IP is banned', async () => {


### PR DESCRIPTION
Related to https://www.notion.so/snapshotlabs/Move-all-messages-to-sequencer-f7843f0b1f3049b79f87647ca652d181
To use only sequencer DB instead of both hub and sequencer DB like before

- [x] Merge only once sequencer DB is successfully synced with hub DB
- [x] Merge after merging https://github.com/snapshot-labs/snapshot-hub/pull/696