### PR TITLE
fix: use moderation data from hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node build/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",
     "test": "PORT=3003 start-server-and-test 'yarn start:test' 3003 'dotenv -e test/.env.test jest --runInBand'",
+    "test:unit": "dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/unit",
     "test:integration": "dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/integration",
     "test:e2e": "PORT=3003 start-server-and-test 'yarn start:test' 3003 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node build/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",
     "test": "PORT=3003 start-server-and-test 'yarn start:test' 3003 'dotenv -e test/.env.test jest --runInBand'",
+    "test:integration": "dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/integration",
     "test:e2e": "PORT=3003 start-server-and-test 'yarn start:test' 3003 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'"
   },
   "eslintConfig": {

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -41,12 +41,12 @@ export async function getSpace(id: string, includeDeleted = false) {
 
   if (!spaces[0]) return false;
 
-  const space = jsonParse(spaces[0].settings, {});
-  if (spaces[0].deleted) space.deleted = true;
-  space.verified = spaces[0].verified;
-  space.flagged = spaces[0].flagged;
-
-  return space;
+  return {
+    ...jsonParse(spaces[0].settings, {}),
+    deleted: spaces[0].deleted === 1,
+    verified: spaces[0].verified === 1,
+    flagged: spaces[0].flagged === 1
+  };
 }
 
 export async function markSpaceAsDeleted(space: string) {

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -35,14 +35,16 @@ export async function getProposal(space, id) {
   return proposal;
 }
 
-export async function getSpace(id, includeDeleted = false) {
-  const query = `SELECT settings, deleted FROM spaces WHERE id = ? AND deleted in (?) LIMIT 1`;
+export async function getSpace(id: string, includeDeleted = false) {
+  const query = `SELECT settings, deleted, flagged, verified FROM spaces WHERE id = ? AND deleted in (?) LIMIT 1`;
   const spaces = await db.queryAsync(query, [id, includeDeleted ? [0, 1] : [0]]);
 
   if (!spaces[0]) return false;
 
   const space = jsonParse(spaces[0].settings, {});
   if (spaces[0].deleted) space.deleted = true;
+  space.verified = spaces[0].verified;
+  space.flagged = spaces[0].flagged;
 
   return space;
 }

--- a/src/helpers/limits.ts
+++ b/src/helpers/limits.ts
@@ -1,5 +1,3 @@
-import { flaggedSpaces, verifiedSpaces } from './moderation';
-
 export const FLAGGED_SPACE_PROPOSAL_DAY_LIMIT = 1;
 export const FLAGGED_SPACE_PROPOSAL_MONTH_LIMIT = 5;
 
@@ -24,15 +22,15 @@ export const ECOSYSTEM_SPACES = [
 export const ACTIVE_PROPOSAL_BY_AUTHOR_LIMIT = 20;
 
 export function getSpaceLimits(space): number[] {
-  if (flaggedSpaces.includes(space)) {
+  if (space.flagged) {
     return [FLAGGED_SPACE_PROPOSAL_DAY_LIMIT, FLAGGED_SPACE_PROPOSAL_MONTH_LIMIT];
   }
 
-  if (ECOSYSTEM_SPACES.includes(space)) {
+  if (ECOSYSTEM_SPACES.includes(space.id)) {
     return [ECOSYSTEM_SPACE_PROPOSAL_DAY_LIMIT, ECOSYSTEM_SPACE_PROPOSAL_MONTH_LIMIT];
   }
 
-  if (verifiedSpaces.includes(space)) {
+  if (space.verified) {
     return [VERIFIED_SPACE_PROPOSAL_DAY_LIMIT, VERIFIED_SPACE_PROPOSAL_MONTH_LIMIT];
   }
 

--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -7,12 +7,10 @@ import { fetchWithKeepAlive } from './utils';
 const sidekickURL = process.env.SIDEKICK_URL || 'https://sh5.co';
 const moderationURL = `${sidekickURL}/api/moderation`;
 
-export let flaggedSpaces: Array<string> = [];
 export let flaggedIps: Array<string> = [];
 export let flaggedAddresses: Array<string> = [];
 export let flaggedProposalTitleKeywords: Array<string> = [];
 export let flaggedProposalBodyKeywords: Array<string> = [];
-export let verifiedSpaces: Array<string> = [];
 
 export async function loadModerationData(url = moderationURL) {
   try {
@@ -24,12 +22,10 @@ export async function loadModerationData(url = moderationURL) {
       return;
     }
 
-    flaggedSpaces = body.flaggedSpaces;
     flaggedIps = body.flaggedIps;
     flaggedAddresses = body.flaggedAddresses;
     flaggedProposalTitleKeywords = body.flaggedProposalTitleKeywords;
     flaggedProposalBodyKeywords = body.flaggedProposalBodyKeywords;
-    verifiedSpaces = body.verifiedSpaces;
   } catch (e: any) {
     capture(e);
   }

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -54,6 +54,10 @@ export async function verify(body): Promise<any> {
 
   const space = await getSpace(msg.space);
 
+  if (!space) {
+    return Promise.reject('invalid space');
+  }
+
   space.id = msg.space;
   const hasTicket = space.strategies.some(strategy => strategy.name === 'ticket');
   const hasVotingValidation =
@@ -151,7 +155,7 @@ export async function verify(body): Promise<any> {
       space.id,
       body.address
     );
-    const [dayLimit, monthLimit] = getSpaceLimits(space.id);
+    const [dayLimit, monthLimit] = getSpaceLimits(space);
 
     if (dayCount >= dayLimit || monthCount >= monthLimit)
       return Promise.reject('proposal limit reached');

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -55,7 +55,7 @@ export async function verify(body): Promise<any> {
   const space = await getSpace(msg.space);
 
   if (!space) {
-    return Promise.reject('invalid space');
+    return Promise.reject('unknown space');
   }
 
   space.id = msg.space;

--- a/test/fixtures/space.ts
+++ b/test/fixtures/space.ts
@@ -13,12 +13,7 @@ const SpacesSqlFixtures: Record<string, any>[] = [
       admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
       symbol: 'TEST',
       network: '1',
-      strategies: [
-        {
-          name: 'ticket',
-          params: {}
-        }
-      ]
+      strategies: []
     }
   },
   {
@@ -34,12 +29,7 @@ const SpacesSqlFixtures: Record<string, any>[] = [
       admins: ['0x87D68ecFBcF53c857ABf494728Cf3DE1016b27B0'],
       symbol: 'TEST2',
       network: '1',
-      strategies: [
-        {
-          name: 'ticket',
-          params: {}
-        }
-      ]
+      strategies: []
     }
   }
 ];

--- a/test/fixtures/space.ts
+++ b/test/fixtures/space.ts
@@ -1,0 +1,47 @@
+// Mock return results from SQL
+const SpacesSqlFixtures: Record<string, any>[] = [
+  {
+    id: 'test.eth',
+    name: 'Test Space',
+    verified: 1,
+    flagged: 0,
+    deleted: 0,
+    created_at: 1649844547,
+    updated_at: 1649844547,
+    settings: {
+      name: 'Test Space',
+      admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
+      symbol: 'TEST',
+      network: '1',
+      strategies: [
+        {
+          name: 'ticket',
+          params: {}
+        }
+      ]
+    }
+  },
+  {
+    id: 'test2.eth',
+    name: 'Test Space 2',
+    verified: 0,
+    flagged: 0,
+    deleted: 0,
+    created_at: 1649844547,
+    updated_at: 1649844547,
+    settings: {
+      name: 'Test Space 2',
+      admins: ['0x87D68ecFBcF53c857ABf494728Cf3DE1016b27B0'],
+      symbol: 'TEST2',
+      network: '1',
+      strategies: [
+        {
+          name: 'ticket',
+          params: {}
+        }
+      ]
+    }
+  }
+];
+
+export default SpacesSqlFixtures;

--- a/test/integration/helpers/actions.test.ts
+++ b/test/integration/helpers/actions.test.ts
@@ -29,12 +29,7 @@ describe('helpers/actions', () => {
         admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
         symbol: 'TEST',
         network: '1',
-        strategies: [
-          {
-            name: 'ticket',
-            params: {}
-          }
-        ]
+        strategies: []
       });
     });
 
@@ -59,12 +54,7 @@ describe('helpers/actions', () => {
         admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
         symbol: 'TEST',
         network: '1',
-        strategies: [
-          {
-            name: 'ticket',
-            params: {}
-          }
-        ]
+        strategies: []
       });
     });
 

--- a/test/integration/helpers/actions.test.ts
+++ b/test/integration/helpers/actions.test.ts
@@ -1,0 +1,75 @@
+import { getSpace } from '../../../src/helpers/actions';
+import db from '../../../src/helpers/mysql';
+import fixtures from '../../fixtures/space';
+
+describe('helpers/actions', () => {
+  afterAll(async () => {
+    await db.endAsync();
+  });
+
+  describe('getSpace()', () => {
+    beforeEach(async () => {
+      const spaces = fixtures.map(space => ({
+        ...space,
+        settings: JSON.stringify(space.settings)
+      }));
+      await db.queryAsync('INSERT INTO snapshot_sequencer_test.spaces SET ?', spaces);
+    });
+
+    afterEach(async () => {
+      await db.queryAsync('DELETE FROM snapshot_sequencer_test.spaces');
+    });
+
+    it('returns the space for the given ID', () => {
+      expect(getSpace('test.eth')).resolves.toEqual({
+        verified: true,
+        flagged: false,
+        deleted: false,
+        name: 'Test Space',
+        admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
+        symbol: 'TEST',
+        network: '1',
+        strategies: [
+          {
+            name: 'ticket',
+            params: {}
+          }
+        ]
+      });
+    });
+
+    it('does not return deleted space by default', async () => {
+      await db.queryAsync(
+        'UPDATE snapshot_sequencer_test.spaces SET deleted = 1 WHERE id = ? LIMIT 1',
+        ['test.eth']
+      );
+      expect(getSpace('test.eth')).resolves.toBe(false);
+    });
+
+    it('returns deleted space when asked', async () => {
+      await db.queryAsync(
+        'UPDATE snapshot_sequencer_test.spaces SET deleted = 1 WHERE id = ? LIMIT 1',
+        ['test.eth']
+      );
+      expect(getSpace('test.eth', true)).resolves.toEqual({
+        verified: true,
+        flagged: false,
+        deleted: true,
+        name: 'Test Space',
+        admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
+        symbol: 'TEST',
+        network: '1',
+        strategies: [
+          {
+            name: 'ticket',
+            params: {}
+          }
+        ]
+      });
+    });
+
+    it('returns false when no space is found', () => {
+      expect(getSpace('test-space.eth')).resolves.toBe(false);
+    });
+  });
+});

--- a/test/integration/helpers/actions.test.ts
+++ b/test/integration/helpers/actions.test.ts
@@ -1,10 +1,11 @@
 import { getSpace } from '../../../src/helpers/actions';
-import db from '../../../src/helpers/mysql';
+import db, { sequencerDB } from '../../../src/helpers/mysql';
 import fixtures from '../../fixtures/space';
 
 describe('helpers/actions', () => {
   afterAll(async () => {
     await db.endAsync();
+    await sequencerDB.endAsync();
   });
 
   describe('getSpace()', () => {

--- a/test/integration/helpers/highlight.test.ts
+++ b/test/integration/helpers/highlight.test.ts
@@ -14,7 +14,8 @@ describe('highlight', () => {
         'DELETE from snapshot_sequencer_test.messages where id = ?',
         'test-exists'
       );
-      return db.endAsync();
+      await db.endAsync();
+      await sequencerDB.endAsync();
     });
 
     it('returns false when message does not exist yet', async () => {

--- a/test/integration/helpers/highlight.test.ts
+++ b/test/integration/helpers/highlight.test.ts
@@ -1,5 +1,5 @@
 import { doesMessageExist, storeMsg } from '../../../src/helpers/highlight';
-import db from '../../../src/helpers/mysql';
+import db, { sequencerDB } from '../../../src/helpers/mysql';
 
 describe('highlight', () => {
   describe('doesMessageExist()', () => {

--- a/test/integration/helpers/moderation.test.ts
+++ b/test/integration/helpers/moderation.test.ts
@@ -1,11 +1,9 @@
 import {
   loadModerationData,
-  flaggedSpaces,
   flaggedIps,
   flaggedAddresses,
   flaggedProposalTitleKeywords,
-  flaggedProposalBodyKeywords,
-  verifiedSpaces
+  flaggedProposalBodyKeywords
 } from '../../../src/helpers/moderation';
 
 describe('moderation', () => {
@@ -14,12 +12,10 @@ describe('moderation', () => {
       it('loads moderation data from sidekick', async () => {
         await loadModerationData();
 
-        expect(flaggedSpaces).not.toHaveLength(0);
         expect(flaggedIps).not.toHaveLength(0);
         expect(flaggedAddresses).not.toHaveLength(0);
         expect(flaggedProposalTitleKeywords).not.toHaveLength(0);
         expect(flaggedProposalBodyKeywords).not.toHaveLength(0);
-        expect(verifiedSpaces).not.toHaveLength(0);
       });
     });
 

--- a/test/integration/ingestor.test.ts
+++ b/test/integration/ingestor.test.ts
@@ -99,7 +99,8 @@ describe('ingestor', () => {
   afterAll(async () => {
     await db.queryAsync('DELETE FROM snapshot_sequencer_test.proposals;');
     await db.queryAsync('DELETE FROM snapshot_sequencer_test.messages;');
-    return await db.endAsync();
+    await db.endAsync();
+    await sequencerDB.endAsync();
   });
 
   it('rejects when the submitter IP is banned', async () => {

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -4,11 +4,13 @@ CREATE TABLE spaces (
   settings JSON,
   verified INT NOT NULL DEFAULT '0',
   deleted INT NOT NULL DEFAULT '0',
+  flagged INT NOT NULL DEFAULT '0',
   created_at BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   PRIMARY KEY (id),
   INDEX name (name),
   INDEX verified (verified),
+  INDEX flagged (flagged),
   INDEX deleted (deleted),
   INDEX created_at (created_at),
   INDEX updated_at (updated_at)
@@ -19,6 +21,7 @@ CREATE TABLE proposals (
   ipfs VARCHAR(64) NOT NULL,
   author VARCHAR(64) NOT NULL,
   created INT(11) NOT NULL,
+  updated INT(11) DEFAULT NULL,
   space VARCHAR(64) NOT NULL,
   network VARCHAR(12) NOT NULL,
   symbol VARCHAR(16) NOT NULL,
@@ -42,10 +45,12 @@ CREATE TABLE proposals (
   scores_total DECIMAL(64,30) NOT NULL,
   scores_updated INT(11) NOT NULL,
   votes INT(12) NOT NULL,
+  flagged INT NOT NULL DEFAULT 0,
   PRIMARY KEY (id),
   INDEX ipfs (ipfs),
   INDEX author (author),
   INDEX created (created),
+  INDEX updated (updated),
   INDEX network (network),
   INDEX space (space),
   INDEX start (start),
@@ -53,7 +58,8 @@ CREATE TABLE proposals (
   INDEX app (app),
   INDEX scores_state (scores_state),
   INDEX scores_updated (scores_updated),
-  INDEX votes (votes)
+  INDEX votes (votes),
+  INDEX flagged (flagged)
 );
 
 CREATE TABLE votes (

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -225,12 +225,14 @@ describe('writer/proposal', () => {
 
     describe('when the proposal contains flagged contents', () => {
       const invalidInput = [
-        [{ ...input, address: FLAGGED_ADDRESSES[0] }, 'submitted address is flagged']
+        ['submitted address is flagged', { ...input, address: FLAGGED_ADDRESSES[0] }]
       ];
 
       it.each(invalidInput)('rejects when the %s', async (title, val) => {
         expect.assertions(1);
-        await expect(writer.verify(val)).rejects.toMatch('wrong');
+        await expect(writer.verify(val)).rejects.toMatch(
+          'invalid proposal, please contact support'
+        );
       });
     });
 

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -200,7 +200,6 @@ describe('writer/proposal', () => {
     });
 
     describe('when the proposal contains flagged contents', () => {
-      const msg = JSON.parse(input.msg);
       const invalidInput = [
         [{ ...input, address: FLAGGED_ADDRESSES[0] }, 'submitted address is flagged']
       ];

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -303,6 +303,13 @@ describe('writer/proposal', () => {
       expect(mockGetProposalsCount).toHaveBeenCalledTimes(1);
     });
 
+    it('rejects if the space is not found', async () => {
+      mockGetSpace.mockResolvedValueOnce(false);
+
+      await expect(writer.verify(input)).rejects.toMatch('unknown space');
+      expect(mockGetSpace).toHaveBeenCalledTimes(1);
+    });
+
     describe('when only members can propose', () => {
       it('rejects if the submitter is not a space member', async () => {
         mockGetSpace.mockResolvedValueOnce({

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -1,6 +1,18 @@
 import * as writer from '../../../src/writer/proposal';
 import input from '../../fixtures/writer-payload/proposal.json';
 import omit from 'lodash/omit';
+import {
+  ECOSYSTEM_SPACE_PROPOSAL_DAY_LIMIT,
+  FLAGGED_SPACE_PROPOSAL_DAY_LIMIT,
+  SPACE_PROPOSAL_DAY_LIMIT,
+  VERIFIED_SPACE_PROPOSAL_DAY_LIMIT,
+  ECOSYSTEM_SPACE_PROPOSAL_MONTH_LIMIT,
+  FLAGGED_SPACE_PROPOSAL_MONTH_LIMIT,
+  SPACE_PROPOSAL_MONTH_LIMIT,
+  VERIFIED_SPACE_PROPOSAL_MONTH_LIMIT,
+  ECOSYSTEM_SPACES,
+  ACTIVE_PROPOSAL_BY_AUTHOR_LIMIT
+} from '../../../src/helpers/limits';
 
 const FLAGGED_ADDRESSES = ['0x0'];
 
@@ -57,7 +69,7 @@ jest.mock('../../../src/helpers/moderation', () => {
 
 describe('writer/proposal', () => {
   describe('verify()', () => {
-    describe.only('when the schema is invalid', () => {
+    describe('when the schema is invalid', () => {
       const msg = JSON.parse(input.msg);
       const invalidMsg = [
         ['unknown field', { ...msg, payload: { ...msg.payload, title: 'title' } }],
@@ -66,6 +78,7 @@ describe('writer/proposal', () => {
       ];
 
       it.each(invalidMsg)('rejects on %s', async (title: string, val: any) => {
+        expect.assertions(1);
         await expect(writer.verify({ ...input, msg: JSON.stringify(val) })).rejects.toMatch(
           'format'
         );
@@ -73,6 +86,8 @@ describe('writer/proposal', () => {
     });
 
     it('rejects if the basic vote choices are not valid', async () => {
+      expect.assertions(1);
+
       const msg = JSON.parse(input.msg);
       msg.payload.type = 'basic';
       msg.payload.choices = ['Good'];
@@ -83,6 +98,7 @@ describe('writer/proposal', () => {
     });
 
     it('does not reject if the basic vote choices are valid', async () => {
+      expect.assertions(2);
       mockGetSpace.mockResolvedValueOnce({
         ...DEFAULT_SPACE,
         voting: { ...DEFAULT_SPACE.voting, type: 'basic' }
@@ -98,6 +114,7 @@ describe('writer/proposal', () => {
 
     describe('when the space has enabled the ticket validation strategy', () => {
       it('rejects if the space does not have voting validation', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           strategies: [{ name: 'ticket' }],
@@ -109,6 +126,7 @@ describe('writer/proposal', () => {
       });
 
       it('rejects if the space voting validation is <any>', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           strategies: [{ name: 'ticket' }],
@@ -120,6 +138,7 @@ describe('writer/proposal', () => {
       });
 
       it('does not reject if the space voting validation is anything else valid than <any>', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           strategies: [{ name: 'ticket' }],
@@ -135,6 +154,7 @@ describe('writer/proposal', () => {
       const VOTING_PERIOD = 1e6;
 
       it('rejects if the proposal voting period is not matching the space', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           voting: { ...DEFAULT_SPACE.voting, period: VOTING_PERIOD }
@@ -145,6 +165,7 @@ describe('writer/proposal', () => {
       });
 
       it('does not reject if the proposal voting period is matching the space', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           voting: { ...DEFAULT_SPACE.voting, period: VOTING_PERIOD }
@@ -164,6 +185,7 @@ describe('writer/proposal', () => {
       const VOTING_DELAY = 1e6;
 
       it('rejects if the proposal voting delay is not matching the space', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           voting: { ...DEFAULT_SPACE.voting, delay: VOTING_DELAY }
@@ -174,6 +196,7 @@ describe('writer/proposal', () => {
       });
 
       it('does not reject if the proposal voting delay is matching the space', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           voting: { ...DEFAULT_SPACE.voting, delay: VOTING_DELAY }
@@ -190,6 +213,7 @@ describe('writer/proposal', () => {
     });
 
     it('rejects if the voting type is invalid', async () => {
+      expect.assertions(2);
       mockGetSpace.mockResolvedValueOnce({
         ...DEFAULT_SPACE,
         voting: { ...DEFAULT_SPACE.voting, type: 'multiple-choices' }
@@ -205,6 +229,7 @@ describe('writer/proposal', () => {
       ];
 
       it.each(invalidInput)('rejects when the %s', async (title, val) => {
+        expect.assertions(1);
         await expect(writer.verify(val)).rejects.toMatch('wrong');
       });
     });
@@ -216,6 +241,7 @@ describe('writer/proposal', () => {
 
       describe('when using a custom of validation', () => {
         it('validates the space validation using snapshot SDK', async () => {
+          expect.assertions(2);
           mockGetSpace.mockResolvedValueOnce({
             ...DEFAULT_SPACE,
             validation: { name: 'gitcoin' }
@@ -228,6 +254,7 @@ describe('writer/proposal', () => {
 
       describe('when using the basic validation with a minimum score', () => {
         it('validates the space validation using snapshot SDK', async () => {
+          expect.assertions(2);
           mockGetSpace.mockResolvedValueOnce({
             ...DEFAULT_SPACE,
             validation: { name: 'basic', params: { minScore: 100 } }
@@ -240,6 +267,7 @@ describe('writer/proposal', () => {
 
       describe('when using the basic validation with no minimum score', () => {
         it('does not validate the space validation', async () => {
+          expect.assertions(1);
           await writer.verify(input);
 
           expect(mockSnapshotUtilsValidate).toHaveBeenCalledTimes(0);
@@ -248,6 +276,7 @@ describe('writer/proposal', () => {
 
       describe('when using the any validation', () => {
         it('does not validate the space validation', async () => {
+          expect.assertions(1);
           await writer.verify(input);
 
           expect(mockSnapshotUtilsValidate).toHaveBeenCalledTimes(0);
@@ -256,6 +285,7 @@ describe('writer/proposal', () => {
     });
 
     it('rejects if the snapshot is in the future', async () => {
+      expect.assertions(1);
       const msg = JSON.parse(input.msg);
       msg.payload.snapshot = Number.MAX_SAFE_INTEGER;
 
@@ -264,34 +294,74 @@ describe('writer/proposal', () => {
       );
     });
 
-    it('rejects if the space has exceeded the proposal daily post limit', async () => {
-      const mockGetProposalsCount = jest
-        .spyOn(writer, 'getProposalsCount')
-        .mockResolvedValueOnce([{ dayCount: 999, monthsCount: 0, activeProposalsByAuthor: 1 }]);
+    it.each([
+      ['flagged', FLAGGED_SPACE_PROPOSAL_DAY_LIMIT, 'flagged', true],
+      ['verified', VERIFIED_SPACE_PROPOSAL_DAY_LIMIT, 'verified', true],
+      ['ecosystem', ECOSYSTEM_SPACE_PROPOSAL_DAY_LIMIT, 'id', ECOSYSTEM_SPACES[0]],
+      ['normal', SPACE_PROPOSAL_DAY_LIMIT, null, null]
+    ])(
+      'rejects if the %s space has exceeded the proposal daily post limit',
+      async (category, limit, key, value) => {
+        expect.assertions(3);
+        const mockGetProposalsCount = jest
+          .spyOn(writer, 'getProposalsCount')
+          .mockResolvedValueOnce([
+            { dayCount: limit + 1, monthCount: 0, activeProposalsByAuthor: 1 }
+          ]);
+        const mockedSpace = { ...DEFAULT_SPACE };
+        if (key && value) {
+          mockedSpace[key] = value;
+        }
+        mockGetSpace.mockResolvedValueOnce(mockedSpace);
 
-      await expect(writer.verify(input)).rejects.toMatch('limit reached');
-      expect(mockGetProposalsCount).toHaveBeenCalledTimes(1);
-    });
+        await expect(writer.verify(input)).rejects.toMatch('limit reached');
+        expect(mockGetProposalsCount).toHaveBeenCalledTimes(1);
+        expect(mockGetSpace).toHaveBeenCalledTimes(1);
+      }
+    );
 
-    it('rejects if the space has exceeded the proposal monthly post limit', async () => {
-      const mockGetProposalsCount = jest
-        .spyOn(writer, 'getProposalsCount')
-        .mockResolvedValueOnce([{ dayCount: 0, monthsCount: 999, activeProposalsByAuthor: 1 }]);
+    it.each([
+      ['flagged', FLAGGED_SPACE_PROPOSAL_MONTH_LIMIT, 'flagged', true],
+      ['verified', VERIFIED_SPACE_PROPOSAL_MONTH_LIMIT, 'verified', true],
+      ['ecosystem', ECOSYSTEM_SPACE_PROPOSAL_MONTH_LIMIT, 'id', ECOSYSTEM_SPACES[0]],
+      ['normal', SPACE_PROPOSAL_MONTH_LIMIT, null, null]
+    ])(
+      'rejects if the space has exceeded the proposal monthly post limit',
+      async (category, limit, key, value) => {
+        expect.assertions(3);
+        const mockGetProposalsCount = jest
+          .spyOn(writer, 'getProposalsCount')
+          .mockResolvedValueOnce([
+            { dayCount: 0, monthCount: limit + 1, activeProposalsByAuthor: 1 }
+          ]);
+        const mockedSpace = { ...DEFAULT_SPACE };
+        if (key && value) {
+          mockedSpace[key] = value;
+        }
+        mockGetSpace.mockResolvedValueOnce(mockedSpace);
 
-      await expect(writer.verify(input)).rejects.toMatch('limit reached');
-      expect(mockGetProposalsCount).toHaveBeenCalledTimes(1);
-    });
+        await expect(writer.verify(input)).rejects.toMatch('limit reached');
+        expect(mockGetProposalsCount).toHaveBeenCalledTimes(1);
+        expect(mockGetSpace).toHaveBeenCalledTimes(1);
+      }
+    );
 
     it('rejects if the user has exceed the number of proposals per space', async () => {
-      const mockGetProposalsCount = jest
-        .spyOn(writer, 'getProposalsCount')
-        .mockResolvedValueOnce([{ dayCount: 0, monthsCount: 0, activeProposalsByAuthor: 999 }]);
+      expect.assertions(2);
+      const mockGetProposalsCount = jest.spyOn(writer, 'getProposalsCount').mockResolvedValueOnce([
+        {
+          dayCount: 0,
+          monthCount: 0,
+          activeProposalsByAuthor: ACTIVE_PROPOSAL_BY_AUTHOR_LIMIT + 1
+        }
+      ]);
 
       await expect(writer.verify(input)).rejects.toMatch('limit reached for author');
       expect(mockGetProposalsCount).toHaveBeenCalledTimes(1);
     });
 
     it('rejects if the space limit checker fails', async () => {
+      expect.assertions(2);
       const mockGetProposalsCount = jest
         .spyOn(writer, 'getProposalsCount')
         .mockImplementationOnce(() => {
@@ -303,6 +373,7 @@ describe('writer/proposal', () => {
     });
 
     it('rejects if the space is not found', async () => {
+      expect.assertions(2);
       mockGetSpace.mockResolvedValueOnce(false);
 
       await expect(writer.verify(input)).rejects.toMatch('unknown space');
@@ -311,6 +382,7 @@ describe('writer/proposal', () => {
 
     describe('when only members can propose', () => {
       it('rejects if the submitter is not a space member', async () => {
+        expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({
           ...DEFAULT_SPACE,
           filters: { onlyMembers: true }
@@ -322,6 +394,7 @@ describe('writer/proposal', () => {
     });
 
     it('verifies a valid input', async () => {
+      expect.assertions(1);
       await expect(writer.verify(input)).resolves.toBeUndefined();
     });
   });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The rateLimit module is still using flagged and verified spaces from sidekick, which is now obsolete

## 💊 Fixes / Solution

Use flagged and verified spaces from hub directly

## 🚧 Changes

- Change the rateLimit code to fetch space's `verified` and `flagged` status directly from the space object 
- the `getSpaceLimits` function inside helpers/limit.ts now take a Space object, instead of spaceId
- When using `getSpace()`, check after that space is set before using

## 🛠️ Tests

- Tests have been added