### PR TITLE
chore: stop logging 429 errors

### DIFF
--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -28,7 +28,6 @@ export default rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   handler: (req, res) => {
-    log.info(`too many requests ${hashedIp(req)}`);
     sendError(
       res,
       'too many requests, refer to https://docs.snapshot.org/tools/api/api-keys#limits',


### PR DESCRIPTION
Stop logging errors for rate limiting.

This is polluting the logs, and those requests are already tracked via the dashboard