### PR TITLE
fix: ensure snapshot value is in the network range

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -1,4 +1,5 @@
 import snapshot from '@snapshot-labs/snapshot.js';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import kebabCase from 'lodash/kebabCase';
 import { jsonParse, validateChoices } from '../helpers/utils';
 import db from '../helpers/mysql';
@@ -154,6 +155,9 @@ export async function verify(body): Promise<any> {
 
   if (msg.payload.snapshot > currentBlockNum)
     return Promise.reject('proposal snapshot must be in past');
+
+  if (msg.payload.snapshot < networks[space.network].start)
+    return Promise.reject('proposal snapshot must be after network start');
 
   try {
     const [{ dayCount, monthCount, activeProposalsByAuthor }] = await getProposalsCount(

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -309,7 +309,17 @@ describe('writer/proposal', () => {
       msg.payload.snapshot = Number.MAX_SAFE_INTEGER;
 
       await expect(writer.verify({ ...input, msg: JSON.stringify(msg) })).rejects.toMatch(
-        'snapshot'
+        'proposal snapshot must be in past'
+      );
+    });
+
+    it('rejects if the snapshot is lower than network start block', async () => {
+      expect.assertions(1);
+      const msg = JSON.parse(input.msg);
+      msg.payload.snapshot = 1000;
+
+      await expect(writer.verify({ ...input, msg: JSON.stringify(msg) })).rejects.toMatch(
+        'proposal snapshot must be after network start'
       );
     });
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

There are no check on the proposal's `snapshot` minimum value. People can submit very small block number not indexed by the nodes, resulting in error while computing voting power and scores.

## 💊 Fixes / Solution

Fix #224 

We should check that the snapshot value is in the range of the chosen network, by ensuring that `snapshot` is always equal or greater than the `start` property in networks.json

## 🚧 Changes

- Check that `snapshot` >= network's `start` block

## 🛠️ Tests

- Submit a proposal with a very small snapshot, it should fail with a `proposal snapshot must be after network start` error