### PR TITLE
fix: rename `_at` suffix from Space timestamp properties

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -5,13 +5,13 @@ export async function addOrUpdateSpace(space: string, settings: any) {
   if (!settings?.name) return false;
   const ts = (Date.now() / 1e3).toFixed();
   const query =
-    'INSERT IGNORE INTO spaces SET ? ON DUPLICATE KEY UPDATE updated_at = ?, settings = ?, name = ?';
+    'INSERT IGNORE INTO spaces SET ? ON DUPLICATE KEY UPDATE updated = ?, settings = ?, name = ?';
   await db.queryAsync(query, [
     {
       id: space,
       name: settings.name,
       created: ts,
-      updated_at: ts,
+      updated: ts,
       settings: JSON.stringify(settings)
     },
     ts,

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -10,7 +10,7 @@ export async function addOrUpdateSpace(space: string, settings: any) {
     {
       id: space,
       name: settings.name,
-      created_at: ts,
+      created: ts,
       updated_at: ts,
       settings: JSON.stringify(settings)
     },

--- a/test/fixtures/space.ts
+++ b/test/fixtures/space.ts
@@ -7,7 +7,7 @@ const SpacesSqlFixtures: Record<string, any>[] = [
     flagged: 0,
     deleted: 0,
     created: 1649844547,
-    updated_at: 1649844547,
+    updated: 1649844547,
     settings: {
       name: 'Test Space',
       admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
@@ -23,7 +23,7 @@ const SpacesSqlFixtures: Record<string, any>[] = [
     flagged: 0,
     deleted: 0,
     created: 1649844547,
-    updated_at: 1649844547,
+    updated: 1649844547,
     settings: {
       name: 'Test Space 2',
       admins: ['0x87D68ecFBcF53c857ABf494728Cf3DE1016b27B0'],

--- a/test/fixtures/space.ts
+++ b/test/fixtures/space.ts
@@ -6,7 +6,7 @@ const SpacesSqlFixtures: Record<string, any>[] = [
     verified: 1,
     flagged: 0,
     deleted: 0,
-    created_at: 1649844547,
+    created: 1649844547,
     updated_at: 1649844547,
     settings: {
       name: 'Test Space',
@@ -22,7 +22,7 @@ const SpacesSqlFixtures: Record<string, any>[] = [
     verified: 0,
     flagged: 0,
     deleted: 0,
-    created_at: 1649844547,
+    created: 1649844547,
     updated_at: 1649844547,
     settings: {
       name: 'Test Space 2',

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -6,14 +6,14 @@ CREATE TABLE spaces (
   deleted INT NOT NULL DEFAULT '0',
   flagged INT NOT NULL DEFAULT '0',
   created BIGINT NOT NULL,
-  updated_at BIGINT NOT NULL,
+  updated BIGINT NOT NULL,
   PRIMARY KEY (id),
   INDEX name (name),
   INDEX verified (verified),
   INDEX flagged (flagged),
   INDEX deleted (deleted),
   INDEX created (created),
-  INDEX updated_at (updated_at)
+  INDEX updated (updated)
 );
 
 CREATE TABLE proposals (

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -5,14 +5,14 @@ CREATE TABLE spaces (
   verified INT NOT NULL DEFAULT '0',
   deleted INT NOT NULL DEFAULT '0',
   flagged INT NOT NULL DEFAULT '0',
-  created_at BIGINT NOT NULL,
+  created BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   PRIMARY KEY (id),
   INDEX name (name),
   INDEX verified (verified),
   INDEX flagged (flagged),
   INDEX deleted (deleted),
-  INDEX created_at (created_at),
+  INDEX created (created),
   INDEX updated_at (updated_at)
 );
 


### PR DESCRIPTION
Ref to https://github.com/snapshot-labs/snapshot-hub/pull/740

Rename the Space's `created_at` and `updated_at` properties to just `created` and `updated`, for consistency