### PR TITLE
feat: add `hibernate` and `reactivate` actions to moderation

### DIFF
--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -66,10 +66,10 @@ export function flagEntity({ type, action, value }) {
       query = `UPDATE proposals SET flagged = 0 WHERE id = ? LIMIT 1`;
       break;
     case 'space-hibernate':
-      query = `UPDATE spaces SET hibernate = 1 WHERE id = ? LIMIT 1`;
+      query = `UPDATE spaces SET hibernated = 1 WHERE id = ? LIMIT 1`;
       break;
     case 'space-reactivate':
-      query = `UPDATE spaces SET hibernate = 0 WHERE id = ? LIMIT 1`;
+      query = `UPDATE spaces SET hibernated = 0 WHERE id = ? LIMIT 1`;
       break;
   }
 

--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -45,7 +45,7 @@ export function flagEntity({ type, action, value }) {
   if (!['proposal', 'space'].includes(type)) throw new Error('invalid type');
   if (type === 'proposal' && !['flag', 'unflag'].includes(action))
     throw new Error('invalid action');
-  if (type === 'space' && !['flag', 'unflag', 'verify'].includes(action))
+  if (type === 'space' && !['flag', 'unflag', 'verify', 'hibernate', 'reactivate'].includes(action))
     throw new Error('invalid action');
 
   let query;
@@ -64,6 +64,12 @@ export function flagEntity({ type, action, value }) {
       break;
     case 'proposal-flag':
       query = `UPDATE proposals SET flagged = 0 WHERE id = ? LIMIT 1`;
+      break;
+    case 'space-hibernate':
+      query = `UPDATE spaces SET hibernate = 1 WHERE id = ? LIMIT 1`;
+      break;
+    case 'space-reactivate':
+      query = `UPDATE spaces SET hibernate = 0 WHERE id = ? LIMIT 1`;
       break;
   }
 


### PR DESCRIPTION
From pitch https://github.com/orgs/snapshot-labs/projects/12/views/7?pane=issue&itemId=43161232

Add support for `hibernate` and `reactivate` on the `/flag` endpoint (so that discord bot cna hibernate and reactivate spaces https://github.com/snapshot-labs/laser/pull/22)