### PR TITLE
feat: add space reactivation action

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -139,6 +139,7 @@ export default async function ingestor(req) {
       };
     }
     if (type === 'flag-proposal') payload = { proposal: message.proposal };
+    if (type === 'reactivate-space') payload = { space: message.space };
 
     if (['vote', 'vote-array', 'vote-string'].includes(type)) {
       if (message.metadata && message.metadata.length > 2000)

--- a/src/writer/index.ts
+++ b/src/writer/index.ts
@@ -2,6 +2,7 @@ import * as proposal from './proposal';
 import * as vote from './vote';
 import * as settings from './settings';
 import * as deleteSpace from './delete-space';
+import * as reactivateSpace from './reactivate-space';
 import * as deleteProposal from './delete-proposal';
 import * as updateProposal from './update-proposal';
 import * as flagProposal from './flag-proposal';
@@ -18,6 +19,7 @@ export default {
   vote,
   settings,
   'delete-space': deleteSpace,
+  'reactivate-space': reactivateSpace,
   'delete-proposal': deleteProposal,
   'update-proposal': updateProposal,
   'flag-proposal': flagProposal,

--- a/src/writer/reactivate-space.ts
+++ b/src/writer/reactivate-space.ts
@@ -23,7 +23,7 @@ export async function verify(body): Promise<any> {
   if (!space) return Promise.reject('unknown space');
   if (!space.hibernated) return Promise.resolve(space);
 
-  const isAuthorizedToReactivate = isAuthorized({
+  const isAuthorizedToReactivate = await isAuthorized({
     space,
     address: body.address
   });

--- a/src/writer/reactivate-space.ts
+++ b/src/writer/reactivate-space.ts
@@ -1,0 +1,35 @@
+import { jsonParse } from '../helpers/utils';
+import db from '../helpers/mysql';
+import { getSpace } from '../helpers/actions';
+
+export function isAuthorized({ space, address }): boolean {
+  const admins = (space?.admins || []).map(admin => admin.toLowerCase());
+  const mods = (space?.moderators || []).map(mod => mod.toLowerCase());
+
+  return admins.includes(address.toLowerCase()) || mods.includes(address.toLowerCase());
+}
+
+export async function verify(body): Promise<any> {
+  const msg = jsonParse(body.msg);
+
+  const space = await getSpace(msg.space);
+  if (!space) return Promise.reject('unknown space');
+  if (!space.hibernated) return Promise.reject('space already active');
+
+  const isAuthorizedToReactivate = isAuthorized({
+    space,
+    address: body.address
+  });
+  if (!isAuthorizedToReactivate) return Promise.reject('not authorized to reactivate space');
+
+  return Promise.resolve(space);
+}
+
+export async function action(body): Promise<void> {
+  const msg = jsonParse(body.msg);
+
+  const query = 'UPDATE space SET hibernated = 0 WßHERE id = ? LIMIT 1';
+  const params: any[] = [msg.payload.space];
+
+  await db.queryAsync(query, params);
+}

--- a/test/unit/writer/reactivate-space.test.ts
+++ b/test/unit/writer/reactivate-space.test.ts
@@ -1,0 +1,71 @@
+import { verify } from '../../../src/writer/reactivate-space';
+
+const input = {
+  msg: { space: 'fabien.eth' },
+  address: '0xF296178d553C8Ec21A2fBD2c5dDa8CA9ac905A00'
+};
+
+const regularAddress = '0xdDE56667616D31974A36F1CFcbe78481BBeE9A0F';
+
+const DEFAULT_SPACE: any = {
+  id: 'fabien.eth',
+  network: '5',
+  voting: { aliased: false, type: 'single-choice' },
+  strategies: [],
+  members: [],
+  admins: ['0xF296178d553C8Ec21A2fBD2c5dDa8CA9ac905A00'],
+  moderators: [],
+  validation: { name: 'basic' },
+  hibernated: true
+};
+
+const mockGetSpace = jest.fn((id: any): any => {
+  return { ...DEFAULT_SPACE, id };
+});
+jest.mock('../../../src/helpers/actions', () => {
+  const originalModule = jest.requireActual('../../../src/helpers/actions');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    getSpace: (id: string) => mockGetSpace(id)
+  };
+});
+
+const mockGetSpaceController = jest.fn((): any => {
+  return '0xF296178d553C8Ec21A2fBD2c5dDa8CA9ac905A00';
+});
+jest.mock('@snapshot-labs/snapshot.js', () => {
+  const originalModule = jest.requireActual('@snapshot-labs/snapshot.js');
+
+  return {
+    ...originalModule,
+    utils: {
+      ...originalModule.utils,
+      getSpaceController: () => mockGetSpaceController()
+    }
+  };
+});
+
+describe('writer/reactivate-space', () => {
+  describe('verify()', () => {
+    it('rejects if the submitter is not authorized to reactivate', () => {
+      return expect(verify({ ...input, address: regularAddress })).rejects.toEqual(
+        'not authorized to reactivate space'
+      );
+    });
+
+    it('rejects if the space is not found', async () => {
+      mockGetSpace.mockResolvedValueOnce(null);
+
+      return expect(verify(input)).rejects.toEqual('unknown space');
+    });
+
+    it('pass if the space is not hibernated', () => {
+      const activeSpace = { ...DEFAULT_SPACE, hibernated: false };
+      mockGetSpace.mockResolvedValueOnce(activeSpace);
+
+      expect(verify(input)).resolves.toBe(activeSpace);
+    });
+  });
+});

--- a/test/unit/writer/reactivate-space.test.ts
+++ b/test/unit/writer/reactivate-space.test.ts
@@ -1,3 +1,4 @@
+import { DESTRUCTION } from 'dns';
 import { verify } from '../../../src/writer/reactivate-space';
 
 const input = {
@@ -66,6 +67,17 @@ describe('writer/reactivate-space', () => {
       mockGetSpace.mockResolvedValueOnce(activeSpace);
 
       expect(verify(input)).resolves.toBe(activeSpace);
+    });
+
+    it('resolves if the submitter is the space controller', () => {
+      mockGetSpaceController.mockResolvedValueOnce(input.address);
+      mockGetSpace.mockResolvedValueOnce(DEFAULT_SPACE);
+      expect(verify(input)).resolves.toBe(DEFAULT_SPACE);
+    });
+
+    it('resolves if the submitter is a space admin', () => {
+      mockGetSpace.mockResolvedValueOnce(DEFAULT_SPACE);
+      expect(verify({ ...input, address: DEFAULT_SPACE.admins[0] })).resolves.toBe(DEFAULT_SPACE);
     });
   });
 });


### PR DESCRIPTION
From https://github.com/orgs/snapshot-labs/projects/12/views/7?pane=issue&itemId=43161232

Add support for space admins/controller to send a signed message, to reactivate the space themselves.

Will be used by https://github.com/snapshot-labs/snapshot/pull/4350, test via snapshot vue app