### PR TITLE
feat: add requestDeduplicator to updateProposalAndVotes

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -8,6 +8,7 @@ import log from './helpers/log';
 import { name, version } from '../package.json';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import poke from './helpers/poke';
+import serve from './helpers/requestDeduplicator';
 
 const router = express.Router();
 const SNAPSHOT_ENV = process.env.NETWORK || 'testnet';
@@ -39,7 +40,7 @@ router.get('/', (req, res) => {
 router.get('/scores/:proposalId', async (req, res) => {
   const { proposalId } = req.params;
   try {
-    const result = await updateProposalAndVotes(proposalId);
+    const result = await serve(proposalId, updateProposalAndVotes, [proposalId]);
     return res.json({ result });
   } catch (e) {
     capture(e);

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -48,6 +48,11 @@ const timeIngestorErrorProcess = new client.Histogram({
   labelNames: ['error', 'type']
 });
 
+export const requestDeduplicatorSize = new client.Gauge({
+  name: 'request_deduplicator_size',
+  help: 'Total number of items in the deduplicator queue'
+});
+
 const ingestorInstrumentation = (req, res, next) => {
   if (req.method !== 'POST' && req.originalUrl !== '/') {
     return next();

--- a/src/helpers/requestDeduplicator.ts
+++ b/src/helpers/requestDeduplicator.ts
@@ -1,0 +1,24 @@
+import { sha256 } from './utils';
+import { requestDeduplicatorSize } from './metrics';
+
+const ongoingRequests = new Map();
+
+export default async function serve(id, action, args) {
+  const key = sha256(id);
+  if (!ongoingRequests.has(key)) {
+    const requestPromise = action(...args)
+      .then(result => {
+        return result;
+      })
+      .catch(e => {
+        throw e;
+      })
+      .finally(() => {
+        ongoingRequests.delete(key);
+      });
+    ongoingRequests.set(key, requestPromise);
+  }
+
+  requestDeduplicatorSize.set(ongoingRequests.size);
+  return ongoingRequests.get(key);
+}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Triggering GET `scores/PROPOSAL-ID` may be costly, and should be done only once when asked multiple time simultaneously.

## 💊 Fixes / Solution

Fix https://github.com/snapshot-labs/snapshot/issues/4485

Install requestDeduplicator (same function as in other repo), to ensure we do not trigger multiple parallel request on the same proposal ID

## 🚧 Changes

- Add requestDeduplicator helper (+ track metrics)
- serve the `/scores/PROPOSAL-ID` endpoint through the requestDeduplicator

