### PR TITLE
feat: Change proposal body limit and strategies limit for turbo spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.4",
-    "@snapshot-labs/snapshot.js": "^0.9.9",
+    "@snapshot-labs/snapshot.js": "^0.10.1",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",
     "cors": "^2.8.5",

--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -9,6 +9,7 @@ const SNAPSHOT_ENV = process.env.NETWORK || 'testnet';
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
 export async function validateSpaceSettings(originalSpace: any) {
+  const spaceType = originalSpace.turbo ? 'turbo' : 'default';
   const space = snapshot.utils.clone(originalSpace);
 
   if (space?.deleted) return Promise.reject('space deleted, contact admin');
@@ -21,6 +22,7 @@ export async function validateSpaceSettings(originalSpace: any) {
   delete space.id;
 
   const schemaIsValid: any = snapshot.utils.validateSchema(snapshot.schemas.space, space, {
+    spaceType,
     snapshotEnv: SNAPSHOT_ENV
   });
 
@@ -60,7 +62,8 @@ export async function verify(body): Promise<any> {
   try {
     await validateSpaceSettings({
       ...msg.payload,
-      deleted: space?.deleted
+      deleted: space?.deleted,
+      turbo: space?.turbo
     });
   } catch (e) {
     return Promise.reject(e);

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -17,9 +17,15 @@ export function getSpaceUpdateError({ type, space }): string | undefined {
 export async function verify(body): Promise<any> {
   const msg = jsonParse(body.msg);
 
+  const space = await getSpace(msg.space);
+  space.id = msg.space;
+
   const schemaIsValid: any = snapshot.utils.validateSchema(
     snapshot.schemas.updateProposal,
-    msg.payload
+    msg.payload,
+    {
+      spaceType: space.turbo ? 'turbo' : 'default'
+    }
   );
   if (schemaIsValid !== true) {
     log.warn('[writer] Wrong proposal format', schemaIsValid);
@@ -41,9 +47,6 @@ export async function verify(body): Promise<any> {
   }
 
   if (proposal.author !== body.address) return Promise.reject('Not the author');
-
-  const space = await getSpace(msg.space);
-  space.id = msg.space;
 
   const spaceUpdateError = getSpaceUpdateError({
     type: msg.payload.type,

--- a/test/unit/writer/settings.test.ts
+++ b/test/unit/writer/settings.test.ts
@@ -9,6 +9,14 @@ function editedInput(payload = {}) {
   return { ...result, msg: JSON.stringify(result.msg) };
 }
 
+function randomStrategies(count = 1) {
+  return Array(count)
+    .fill(0)
+    .map(() => ({
+      name: `strategy-${Math.floor(Math.random() * 1000)}`
+    }));
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mockGetSpace = jest.fn((_): any => {
   return spacesGetSpaceFixtures;
@@ -72,6 +80,27 @@ describe('writer/settings', () => {
       });
       it.todo('rejects if the submitter does not have permission');
       it.todo('rejects if the submitter does not have permission to change admin');
+
+      it('rejects if passing more than 8 strategies for normal space', async () => {
+        return expect(
+          verify(
+            editedInput({
+              strategies: randomStrategies(10)
+            })
+          )
+        ).rejects.toContain('wrong space format');
+      });
+
+      it('rejects if passing more than 10 strategies for turbo space', async () => {
+        mockGetSpace.mockResolvedValueOnce({ ...spacesGetSpaceFixtures, turbo: true });
+        return expect(
+          verify(
+            editedInput({
+              strategies: randomStrategies(12)
+            })
+          )
+        ).rejects.toContain('wrong space format');
+      });
     });
 
     describe('on valid data', () => {
@@ -105,6 +134,31 @@ describe('writer/settings', () => {
         it('returns a Promise resolve', async () => {
           return expect(
             verify(editedInput({ validation: { name: 'any' }, filters: { onlyMembers: true } }))
+          ).resolves.toBe(undefined);
+        });
+      });
+
+      describe('with correct number of strategies for normal spaces', () => {
+        it('returns a Promise resolve', async () => {
+          return expect(
+            verify(
+              editedInput({
+                strategies: randomStrategies(8)
+              })
+            )
+          ).resolves.toBe(undefined);
+        });
+      });
+
+      describe('with correct number of strategies for turbo spaces', () => {
+        it('returns a Promise resolve', async () => {
+          mockGetSpace.mockResolvedValueOnce({ ...spacesGetSpaceFixtures, turbo: true });
+          return expect(
+            verify(
+              editedInput({
+                strategies: randomStrategies(10)
+              })
+            )
           ).resolves.toBe(undefined);
         });
       });

--- a/test/unit/writer/settings.test.ts
+++ b/test/unit/writer/settings.test.ts
@@ -1,6 +1,7 @@
 import { verify } from '../../../src/writer/settings';
 import { spacesGetSpaceFixtures } from '../../fixtures/space';
 import input from '../../fixtures/writer-payload/space.json';
+import SpaceSchema from '@snapshot-labs/snapshot.js/src/schemas/space.json';
 
 function editedInput(payload = {}) {
   const result = { ...input, msg: JSON.parse(input.msg) };
@@ -80,23 +81,26 @@ describe('writer/settings', () => {
       });
       it.todo('rejects if the submitter does not have permission');
       it.todo('rejects if the submitter does not have permission to change admin');
-
-      it('rejects if passing more than 8 strategies for normal space', async () => {
+      const maxStrategiesWithSpaceType =
+        SpaceSchema.definitions.Space.properties.strategies.maxItemsWithSpaceType;
+      const maxStrategiesForNormalSpace = maxStrategiesWithSpaceType['default'];
+      const maxStrategiesForTurboSpace = maxStrategiesWithSpaceType['turbo'];
+      it(`rejects if passing more than ${maxStrategiesForNormalSpace} strategies for normal space`, async () => {
         return expect(
           verify(
             editedInput({
-              strategies: randomStrategies(10)
+              strategies: randomStrategies(maxStrategiesForNormalSpace + 2)
             })
           )
         ).rejects.toContain('wrong space format');
       });
 
-      it('rejects if passing more than 10 strategies for turbo space', async () => {
+      it(`rejects if passing more than ${maxStrategiesForTurboSpace} strategies for turbo space`, async () => {
         mockGetSpace.mockResolvedValueOnce({ ...spacesGetSpaceFixtures, turbo: true });
         return expect(
           verify(
             editedInput({
-              strategies: randomStrategies(12)
+              strategies: randomStrategies(maxStrategiesForTurboSpace + 2)
             })
           )
         ).rejects.toContain('wrong space format');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,10 +1299,10 @@
   dependencies:
     "@sentry/node" "^7.81.1"
 
-"@snapshot-labs/snapshot.js@^0.9.9":
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.9.9.tgz#c7c7f8209129a38e50621aa325833ddd373b23e1"
-  integrity sha512-9c9GVphUs/JwnNrQ39wvpjHhSZ3zqKUH5CSRXacwU1DSCmAg3/b21hauxavAUgK40oXCPkyZ5O1jrGKjbHeT8Q==
+"@snapshot-labs/snapshot.js@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.10.1.tgz#d783ee394d6e3ad3d3a6e91fea67411752d15180"
+  integrity sha512-PacD8HdsYZhb1Yifp6n+11Og+nZUvGhTosu+ejnEwhP6zQOFMg6gaIEsWGjoAMnjos0sgA/oIbWdPIzqJRTECw==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"


### PR DESCRIPTION
Change proposal body limit and strategies limit based on space type

### How to test:
- Use UI from https://github.com/snapshot-labs/snapshot/pull/4495/
- Add 10 strategies in space settings for turbo spaces
- Add 8 strategies in space settings for normal spaces
- Proposal body with 20000 characters for turbo spaces
- Proposal body with 10000 characters for normal spaces 
- Update proposal with different chars length