### PR TITLE
fix: relax node version to allow node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,5 @@
     "prettier": "^3.0.3",
     "start-server-and-test": "^2.0.0",
     "ts-jest": "^29.1.1"
-  },
-  "engines": {
-    "node": "^16.0.0"
   }
 }


### PR DESCRIPTION
Relax nodejs version to allow node 18.

Test have been run on node 18, and pass