### PR TITLE
fix: fix invalid scores array length after choices update

### DIFF
--- a/src/scores.ts
+++ b/src/scores.ts
@@ -100,7 +100,7 @@ const pendingRequests = {};
 
 export async function updateProposalAndVotes(proposalId: string, force = false) {
   const proposal = await getProposal(proposalId);
-  if (!proposal) return false;
+  if (!proposal || proposal.state === 'pending') return false;
   if (proposal.scores_state === 'final') return true;
 
   if (!force && proposal.privacy === 'shutter' && proposal.state === 'closed') {

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -67,11 +67,13 @@ export async function action(body, ipfs): Promise<void> {
     ipfs,
     updated,
     type: msg.payload.type,
-    plugins: plugins,
+    plugins,
     title: msg.payload.name,
     body: msg.payload.body,
     discussion: msg.payload.discussion,
-    choices: JSON.stringify(msg.payload.choices)
+    choices: JSON.stringify(msg.payload.choices),
+    scores: JSON.stringify([]),
+    scores_by_strategy: JSON.stringify([])
   };
 
   const query = 'UPDATE proposals SET ? WHERE id = ? LIMIT 1';


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When updating a proposal with new choices, and when the `scores` and `scores_by_strategy` properties have been updated with empty values (eg. `[[0]]` instead of default `[]`), these fields are not updated, causing them to not have same number of element as the new choices element.

This cause errors on the UI side, which expect a `score` for each `choice`.

## 💊 Fixes / Solution

Fix #276 

## 🚧 Changes

- On proposal update, reset the `scores` and `scores_by_strategy` to an empty array. This reset does not cause side effect, as pending proposals does not have any scores yet.
- Also disable any `scores` and `scores_by_strategy` update when proposal is pending