### PR TITLE
fix: invalidate proposal score when out-of-range

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -42,10 +42,10 @@ router.get('/scores/:proposalId', async (req, res) => {
   try {
     const result = await serve(proposalId, updateProposalAndVotes, [proposalId]);
     return res.json({ result });
-  } catch (e) {
+  } catch (e: any) {
     capture(e);
     log.warn(`[api] updateProposalAndVotes() failed ${proposalId}, ${JSON.stringify(e)}`);
-    return res.json({ error: 'failed', message: e });
+    return res.json({ error: 'failed', message: e.message || e });
   }
 });
 

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -96,6 +96,11 @@ async function updateProposalScores(proposalId: string, scores: any, votes: numb
   ]);
 }
 
+async function invalidateProposalScore(proposalId: string) {
+  const query = `UPDATE proposals SET scores_state = ? WHERE id = ? LIMIT 1;`;
+  await db.queryAsync(query, ['invalid', proposalId]);
+}
+
 const pendingRequests = {};
 
 export async function updateProposalAndVotes(proposalId: string, force = false) {
@@ -114,7 +119,7 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
     (proposal.votes > 30000 && proposal.scores_updated > ts - 300) ||
     pendingRequests[proposalId]
   ) {
-    console.log(
+    log.info(
       'ignore score calculation',
       proposal.space,
       proposalId,
@@ -171,10 +176,20 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
     if (!isFinal) await updateVotesVp(votes, vpState, proposalId);
 
     // Store scores
-    await updateProposalScores(proposalId, results, votes.length);
-    log.info(
-      `[scores] Proposal updated ${proposal.id}, ${proposal.space}, ${results.scores_state}, ${votes.length}`
-    );
+    try {
+      await updateProposalScores(proposalId, results, votes.length);
+      log.info(
+        `[scores] Proposal updated ${proposal.id}, ${proposal.space}, ${results.scores_state}, ${votes.length}`
+      );
+    } catch (e: any) {
+      if (proposal.state === 'closed' && e.code === 'ER_WARN_DATA_OUT_OF_RANGE') {
+        log.info(`[scores] Invalid final scores_total: ${results.scores_total}`, e);
+        await invalidateProposalScore(proposalId);
+        throw new Error('Invalid out of range score');
+      } else {
+        throw e;
+      }
+    }
 
     delete pendingRequests[proposalId];
     return true;

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -182,9 +182,11 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
         `[scores] Proposal updated ${proposal.id}, ${proposal.space}, ${results.scores_state}, ${votes.length}`
       );
     } catch (e: any) {
-      if (proposal.state === 'closed' && e.code === 'ER_WARN_DATA_OUT_OF_RANGE') {
+      if (e.code === 'ER_WARN_DATA_OUT_OF_RANGE') {
         log.info(`[scores] Invalid final scores_total: ${results.scores_total}`, e);
-        await invalidateProposalScore(proposalId);
+        if (proposal.state === 'closed') {
+          await invalidateProposalScore(proposalId);
+        }
         throw new Error('Invalid out of range score');
       } else {
         throw e;


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When computing final proposal scores, some computation fail with the sql `ER_WARN_DATA_OUT_OF_RANGE` error.

This happens when the total scores returned by the strategies exceed the allowed size for the SQL column (`decimal(64,30)`). Those kind of error happen when the total score is something like `1e47`

## 💊 Fixes / Solution

Fix #279 
Fix #281 
Fix [SNAPSHOT-SEQUENCER-2P](https://snapshot-labs.sentry.io/issues/4847351103/?referrer=github_integration)

In case total score is invalid, rescue the error, and return an appropriate message to show when calling `/scores/proposalID`.

## 🚧 Changes

- In case of `ER_WARN_DATA_OUT_OF_RANGE` on a closed proposal, mark its score_state as `invalid`
- Return `{"error":"failed","message":"Invalid out of range score"}` when computing fail with out-of-range score, when asked via `/scores/:proposalId`

## 🛠️ Tests

- Need to test local, by copying the space, votes [0xdc4c6a40bdfb106006507c61237a2f1a4db6b721e0b8444359e7bfcc9b83f5e9](https://snapshot.org/#/figure1.eth/proposal/0xdc4c6a40bdfb106006507c61237a2f1a4db6b721e0b8444359e7bfcc9b83f5e9)
- Set the proposal `scores_state` to `pending` in the db
- Call sequencer: http://localhost:3001/scores/0xdc4c6a40bdfb106006507c61237a2f1a4db6b721e0b8444359e7bfcc9b83f5e9
- It should return `{"error":"failed","message":"Invalid out of range score"}`
- The `scores_state` should be updated to `invalid`

If the proposal was not closed yet, it should not set the `scores_state` to `invalid`, but call to sequencer should still return the same error message

## Other

Additionally, should we update https://github.com/snapshot-labs/snapshot-strategies?tab=readme-ov-file#code to define guideline about the score value ? (max value, best practice, etc ...)