### PR TITLE
fix: auto flag proposal when the body contains flagged links

### DIFF
--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -21,7 +21,7 @@ export async function loadModerationData(url = moderationURL): Promise<boolean> 
     }
 
     flaggedIps = body.flaggedIps;
-    flaggedLinks = body.flaggedLinks;
+    flaggedLinks = (body.flaggedLinks || []).filter((a: string) => a?.length > 0);
     flaggedAddresses = (body.flaggedAddresses || []).map((a: string) => a.toLowerCase());
 
     return true;
@@ -38,10 +38,9 @@ export default async function run() {
 }
 
 export function containsFlaggedLinks(body: string, links = flaggedLinks): boolean {
-  const normalizedLinks = links.filter(a => a?.length > 0);
-  if (normalizedLinks.length === 0) return false;
+  if (links.length === 0) return false;
 
-  return new RegExp(normalizedLinks.join('|'), 'i').test(body);
+  return new RegExp(links.join('|'), 'i').test(body);
 }
 
 export function flagEntity({ type, action, value }) {

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -234,7 +234,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     scores_updated: 0,
     votes: 0,
     validation,
-    flagged: +containsFlaggedLinks(msg.payload.body) ? 1 : 0
+    flagged: +containsFlaggedLinks(msg.payload.body)
   };
 
   const query = 'INSERT IGNORE INTO proposals SET ?; ';

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -234,7 +234,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     scores_updated: 0,
     votes: 0,
     validation,
-    flagged: containsFlaggedLinks(msg.payload.body) ? 1 : 0
+    flagged: +containsFlaggedLinks(msg.payload.body) ? 1 : 0
   };
 
   const query = 'INSERT IGNORE INTO proposals SET ?; ';

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -7,7 +7,7 @@ import { getSpace } from '../helpers/actions';
 import log from '../helpers/log';
 import { ACTIVE_PROPOSAL_BY_AUTHOR_LIMIT, getSpaceLimits } from '../helpers/limits';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { flaggedAddresses } from '../helpers/moderation';
+import { flaggedAddresses, containsFlaggedLinks } from '../helpers/moderation';
 import { validateSpaceSettings } from './settings';
 
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
@@ -233,8 +233,10 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     scores_total: 0,
     scores_updated: 0,
     votes: 0,
-    validation
+    validation,
+    flagged: containsFlaggedLinks(msg.payload.body) ? 1 : 0
   };
+
   const query = 'INSERT IGNORE INTO proposals SET ?; ';
   const params: any[] = [proposal];
 

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -75,7 +75,7 @@ export async function action(body, ipfs): Promise<void> {
     choices: JSON.stringify(msg.payload.choices),
     scores: JSON.stringify([]),
     scores_by_strategy: JSON.stringify([]),
-    flagged: +containsFlaggedLinks(msg.proposal.body)
+    flagged: +containsFlaggedLinks(msg.payload.body)
   };
 
   const query = 'UPDATE proposals SET ? WHERE id = ? LIMIT 1';

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -3,6 +3,7 @@ import { jsonParse, validateChoices } from '../helpers/utils';
 import db from '../helpers/mysql';
 import { getSpace, getProposal } from '../helpers/actions';
 import log from '../helpers/log';
+import { containsFlaggedLinks } from '../helpers/moderation';
 
 // We don't need most of the checks used https://github.com/snapshot-labs/snapshot-sequencer/blob/89992b49c96fedbbbe33b42041c9cbe5a82449dd/src/writer/proposal.ts#L62
 // because we assume that those checks were already done during the proposal creation
@@ -73,7 +74,8 @@ export async function action(body, ipfs): Promise<void> {
     discussion: msg.payload.discussion,
     choices: JSON.stringify(msg.payload.choices),
     scores: JSON.stringify([]),
-    scores_by_strategy: JSON.stringify([])
+    scores_by_strategy: JSON.stringify([]),
+    flagged: +containsFlaggedLinks(msg.proposal.body)
   };
 
   const query = 'UPDATE proposals SET ? WHERE id = ? LIMIT 1';

--- a/test/integration/helpers/moderation.test.ts
+++ b/test/integration/helpers/moderation.test.ts
@@ -42,6 +42,10 @@ describe('moderation', () => {
         setData({ flaggedLinks: ['https://a.com'] });
       });
 
+      afterAll(() => {
+        setData({ flaggedLinks: [] });
+      });
+
       it('returns true if body contains flagged links', () => {
         expect(containsFlaggedLinks('this is a link https://a.com')).toBe(true);
       });
@@ -52,6 +56,10 @@ describe('moderation', () => {
     });
 
     describe('setData()', () => {
+      afterAll(() => {
+        setData({ flaggedLinks: [] });
+      });
+
       it('removes invalid data from flaggedLink', () => {
         // @ts-ignore
         setData({ flaggedLinks: ['https://a.com', null, false, '', 0] });

--- a/test/integration/helpers/moderation.test.ts
+++ b/test/integration/helpers/moderation.test.ts
@@ -1,4 +1,9 @@
-import { loadModerationData, flaggedIps, flaggedAddresses } from '../../../src/helpers/moderation';
+import {
+  loadModerationData,
+  flaggedIps,
+  flaggedAddresses,
+  containsFlaggedLinks
+} from '../../../src/helpers/moderation';
 
 describe('moderation', () => {
   describe('loadModerationData()', () => {
@@ -27,6 +32,24 @@ describe('moderation', () => {
 
       it('returns nothing on not-json response', async () => {
         await expect(loadModerationData('https://snapshot.org')).resolves.toBe(false);
+      });
+    });
+
+    describe('containsFlaggedLinks()', () => {
+      it('returns true if body contains flagged links', () => {
+        expect(containsFlaggedLinks('this is a link https://a.com', ['https://a.com'])).toBe(true);
+      });
+
+      it('returns false if body does not contain flagged links', () => {
+        expect(containsFlaggedLinks('this is a link https://b.com', ['https://a.com'])).toBe(false);
+      });
+
+      it('returns false if flagged links are empty', () => {
+        expect(containsFlaggedLinks('this is a link https://a.com', [])).toBe(false);
+      });
+
+      it('returns false if flagged links contains empty values', () => {
+        expect(containsFlaggedLinks('this is a link https://a.com', [''])).toBe(false);
       });
     });
   });

--- a/test/integration/helpers/moderation.test.ts
+++ b/test/integration/helpers/moderation.test.ts
@@ -1,18 +1,20 @@
 import {
   loadModerationData,
-  flaggedIps,
-  flaggedAddresses,
-  containsFlaggedLinks
+  containsFlaggedLinks,
+  setData,
+  flaggedLinks,
+  flaggedAddresses
 } from '../../../src/helpers/moderation';
 
 describe('moderation', () => {
   describe('loadModerationData()', () => {
     describe('on success', () => {
       it('loads moderation data from sidekick', async () => {
-        await loadModerationData();
+        const result = await loadModerationData();
 
-        expect(flaggedIps).not.toHaveLength(0);
-        expect(flaggedAddresses).not.toHaveLength(0);
+        expect(result!.flaggedIps).not.toHaveLength(0);
+        expect(result!.flaggedAddresses).not.toHaveLength(0);
+        expect(result!.flaggedLinks).not.toHaveLength(0);
       });
     });
 
@@ -25,31 +27,40 @@ describe('moderation', () => {
       ])(
         'returns nothing on network error (%s)',
         async (title, url) => {
-          await expect(loadModerationData(url)).resolves.toBe(false);
+          await expect(loadModerationData(url)).resolves.toBe(undefined);
         },
         6e3
       );
 
       it('returns nothing on not-json response', async () => {
-        await expect(loadModerationData('https://snapshot.org')).resolves.toBe(false);
+        await expect(loadModerationData('https://snapshot.org')).resolves.toBe(undefined);
       });
     });
 
     describe('containsFlaggedLinks()', () => {
+      beforeAll(() => {
+        setData({ flaggedLinks: ['https://a.com'] });
+      });
+
       it('returns true if body contains flagged links', () => {
-        expect(containsFlaggedLinks('this is a link https://a.com', ['https://a.com'])).toBe(true);
+        expect(containsFlaggedLinks('this is a link https://a.com')).toBe(true);
       });
 
       it('returns false if body does not contain flagged links', () => {
-        expect(containsFlaggedLinks('this is a link https://b.com', ['https://a.com'])).toBe(false);
+        expect(containsFlaggedLinks('this is a link https://b.com')).toBe(false);
+      });
+    });
+
+    describe('setData()', () => {
+      it('removes invalid data from flaggedLink', () => {
+        // @ts-ignore
+        setData({ flaggedLinks: ['https://a.com', null, false, '', 0] });
+        expect(flaggedLinks).toEqual(['https://a.com']);
       });
 
-      it('returns false if flagged links are empty', () => {
-        expect(containsFlaggedLinks('this is a link https://a.com', [])).toBe(false);
-      });
-
-      it('returns false if flagged links contains empty values', () => {
-        expect(containsFlaggedLinks('this is a link https://a.com', [''])).toBe(false);
+      it('lower cases the flaggedAddresses', () => {
+        setData({ flaggedAddresses: ['0xAa'] });
+        expect(flaggedAddresses).toEqual(['0xaa']);
       });
     });
   });

--- a/test/integration/writer/proposal.test.ts
+++ b/test/integration/writer/proposal.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../../src/helpers/moderation', () => {
 describe('writer/proposal', () => {
   describe('action()', () => {
     afterAll(async () => {
-      await db.queryAsync('DELETE FROM proposals');
+      await db.queryAsync('DELETE FROM proposals where id in (?)', [['0x01', '0x02']]);
       await db.endAsync();
       await sequencerDB.endAsync();
     });

--- a/test/integration/writer/proposal.test.ts
+++ b/test/integration/writer/proposal.test.ts
@@ -1,0 +1,49 @@
+import { action } from '../../../src/writer/proposal';
+import db, { sequencerDB } from '../../../src/helpers/mysql';
+import input from '../../fixtures/writer-payload/proposal.json';
+
+const mockContainsFlaggedLinks = jest.fn((): any => {
+  return false;
+});
+
+jest.mock('../../../src/helpers/moderation', () => {
+  const originalModule = jest.requireActual('../../../src/helpers/moderation');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    containsFlaggedLinks: () => mockContainsFlaggedLinks()
+  };
+});
+
+describe('writer/proposal', () => {
+  describe('action()', () => {
+    afterAll(async () => {
+      await db.queryAsync('DELETE FROM proposals');
+      await db.endAsync();
+      await sequencerDB.endAsync();
+    });
+
+    describe('when the proposal contains flagged links', () => {
+      it('flagged the proposal', async () => {
+        expect.assertions(1);
+        mockContainsFlaggedLinks.mockReturnValueOnce(true);
+        const id = '0x01';
+        await action(input, 'ipfs', 'receipt', id);
+
+        const [proposal] = await db.queryAsync('SELECT * FROM proposals WHERE id = ?', [id]);
+        expect(proposal.flagged).toBe(1);
+      });
+    });
+
+    describe('when the proposal does not contain flagged links', () => {
+      it('does not flag proposal', async () => {
+        const id = '0x02';
+        await action(input, 'ipfs', 'receipt', id);
+
+        const [proposal] = await db.queryAsync('SELECT * FROM proposals WHERE id = ?', [id]);
+        expect(proposal.flagged).toBe(0);
+      });
+    });
+  });
+});

--- a/test/integration/writer/proposal.test.ts
+++ b/test/integration/writer/proposal.test.ts
@@ -19,30 +19,35 @@ jest.mock('../../../src/helpers/moderation', () => {
 describe('writer/proposal', () => {
   describe('action()', () => {
     afterAll(async () => {
-      await db.queryAsync('DELETE FROM proposals where id in (?)', [['0x01', '0x02']]);
+      await db.queryAsync('DELETE FROM proposals where id in (?)', [
+        ['0x01-flagged', '0x02-non-flagged']
+      ]);
       await db.endAsync();
       await sequencerDB.endAsync();
     });
 
     describe('when the proposal contains flagged links', () => {
-      it('flagged the proposal', async () => {
-        expect.assertions(1);
+      it('flag the proposal', async () => {
+        expect.assertions(2);
         mockContainsFlaggedLinks.mockReturnValueOnce(true);
-        const id = '0x01';
+        const id = '0x01-flagged';
         await action(input, 'ipfs', 'receipt', id);
 
         const [proposal] = await db.queryAsync('SELECT * FROM proposals WHERE id = ?', [id]);
         expect(proposal.flagged).toBe(1);
+        expect(mockContainsFlaggedLinks).toHaveBeenCalledTimes(1);
       });
     });
 
     describe('when the proposal does not contain flagged links', () => {
       it('does not flag proposal', async () => {
-        const id = '0x02';
+        expect.assertions(2);
+        const id = '0x02-non-flagged';
         await action(input, 'ipfs', 'receipt', id);
 
         const [proposal] = await db.queryAsync('SELECT * FROM proposals WHERE id = ?', [id]);
         expect(proposal.flagged).toBe(0);
+        expect(mockContainsFlaggedLinks).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Proposals with flaggedLinks and proposals flagged manually are handled differently.

## 💊 Fixes / Solution

Auto-flag proposals containing flagged links, so the the only source of truth for flagging is the `flagged` column in the proposals table

## 🚧 Changes

- Load `flaggedLinks` data from moderation endpoint
- When creating and updating proposals, flag proposal when the body contains flagged links

## 🛠️ Tests

- create some proposals with body containing flagged links
- the proposal should be flagged, without manual moderation