### PR TITLE
fix: handle error when unable to get current block

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -153,9 +153,13 @@ export async function verify(body): Promise<any> {
     }
   }
 
-  const provider = snapshot.utils.getProvider(space.network, { broviderUrl });
-
-  const currentBlockNum = parseInt(await provider.getBlockNumber());
+  let currentBlockNum = 0;
+  try {
+    const provider = snapshot.utils.getProvider(space.network, { broviderUrl });
+    currentBlockNum = parseInt(await provider.getBlockNumber());
+  } catch {
+    return Promise.reject('unable to fetch current block number');
+  }
 
   if (msg.payload.snapshot > currentBlockNum)
     return Promise.reject('proposal snapshot must be in past');


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We got some errors due to connection issues with brovider

## 💊 Fixes / Solution

Fix #286
Fix [SNAPSHOT-SEQUENCER-2V](https://snapshot-labs.sentry.io/issues/4912710121/?referrer=github_integration)

Handle errors for remaining direct calls to brovider

## 🚧 Changes

- Add a try/catch when calling brovider
