### PR TITLE
fix: ignore redis error on rate limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.21",
     "mysql": "^2.18.1",
     "node-fetch": "^2.7.0",
-    "rate-limit-redis": "^3.0.2",
+    "rate-limit-redis": "^3.1.0",
     "redis": "^4.6.8",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -18,6 +18,7 @@ export default rateLimit({
       429
     );
   },
+  skip: () => redisClient && !redisClient.isReady,
   store: redisClient
     ? new RedisStore({
         sendCommand: (...args: string[]) => redisClient.sendCommand(args),

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -18,7 +18,7 @@ export default rateLimit({
       429
     );
   },
-  skip: () => redisClient && !redisClient.isReady,
+  skip: () => !redisClient?.isReady,
   store: redisClient
     ? new RedisStore({
         sendCommand: (...args: string[]) => redisClient.sendCommand(args),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4699,10 +4699,10 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-rate-limit-redis@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rate-limit-redis/-/rate-limit-redis-3.0.2.tgz#0c923db4ab77960ef1c5c495f14c08e6fad602de"
-  integrity sha512-4SBK6AzIr9PKkCF4HmSDcJH2O2KKMF3fZEcsbNMXyaL5I9d6X71uOreUldFRiyrRyP+qkQrTxzJ38ZKKN+sScw==
+rate-limit-redis@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rate-limit-redis/-/rate-limit-redis-3.1.0.tgz#1af407dbe43e8d04b0234ca0b5d0318df8db4e55"
+  integrity sha512-guCQGRQhsOlTR4VNHRnksMeet/3ImfdxIQgWP6In4FphJjUbORe0F4XeFshLnbc9xcuFUv9jZL44TgUMSz4XPQ==
 
 raw-body@2.5.1:
   version "2.5.1"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

On redis connection issues, rate-limit middleware is blocking the whole request workflow, and not letting through any requests.

## 💊 Fixes / Solution

Fix #289 

On redis connection issues, rate-limit middleware should be ignored, and all requests should bypass the middleware.

## 🚧 Changes

- Bypass rate-limit middleware when redis is not ready
- Update `rate-limit-redis` package to 3.1.0, to support redis reconnection, else will throw https://github.com/express-rate-limit/rate-limit-redis/issues/144

## 🛠️ Tests

- Start your redis server
- yarn dev
- Send some requests to localhost:3001
- It should returns headers like `Ratelimit-Limit`
- Stop the redis server
- It should start logging connections error on the `yarn dev` console
- Send some requests to localhost:3001
- It should return results as usual
- The headers `Ratelimit-Limit` should be missing from the headers
- Start redis again
- Send some requests to localhost:3001
- Headers `Ratelimit-Limit` should be back