### PR TITLE
fix: undefined logs on alias action

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -230,10 +230,11 @@ export default async function ingestor(req) {
     }
 
     const shortId = `${id.slice(0, 7)}...`;
+    const spaceText = message.space ? ` on "${message.space}"` : '';
     log.info(
-      `[ingestor] New "${type}" on "${message.space}",  for "${
-        body.address
-      }", id: ${shortId}, IP: ${sha256(getIp(req))}`
+      `[ingestor] New "${type}"${spaceText} for "${body.address}", id: ${shortId}, IP: ${sha256(
+        getIp(req)
+      )}`
     );
 
     success = 1;


### PR DESCRIPTION
### Problem:

In logs i find logs like this:
```
New "alias" on "undefined",  for "0xF5b32cd4Fda955B099d8436e30e...
```

This is confusing, so adding `spaceText` only when space is available 