### PR TITLE
fix: Store quorum type on proposal

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -245,6 +245,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     start: parseInt(msg.payload.start || '0'),
     end: parseInt(msg.payload.end || '0'),
     quorum,
+    quorum_type: (quorum && spaceSettings.voting.quorumType) || '',
     privacy: spaceSettings.voting?.privacy || '',
     snapshot: proposalSnapshot || 0,
     app: kebabCase(msg.payload.app || ''),

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -245,7 +245,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     start: parseInt(msg.payload.start || '0'),
     end: parseInt(msg.payload.end || '0'),
     quorum,
-    quorum_type: (quorum && spaceSettings.voting.quorumType) || '',
+    quorum_type: (quorum && spaceSettings.voting?.quorumType) || '',
     privacy: spaceSettings.voting?.privacy || '',
     snapshot: proposalSnapshot || 0,
     app: kebabCase(msg.payload.app || ''),

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE proposals (
   start INT(11) NOT NULL,
   end INT(11) NOT NULL,
   quorum DECIMAL(64,30) NOT NULL,
+  quorum_type VARCHAR(24) NOT NULL DEFAULT '',
   privacy VARCHAR(24) NOT NULL,
   snapshot INT(24) NOT NULL,
   app VARCHAR(24) NOT NULL,


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot/issues/4600

- [x] Merge only after adding quorum_type to proposals table
```
ALTER TABLE proposals
ADD COLUMN quorum_type VARCHAR(24) DEFAULT '' AFTER quorum;
```

### How to test:
- Add `quorumType` on space settings
- On proposal creation, we should be able to store `quorumType` on proposals table