### PR TITLE
Fix: On proposal creation check if snapshot block exist

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -172,19 +172,16 @@ export async function verify(body): Promise<any> {
     }
   }
 
-  let currentBlockNum = 0;
-  try {
-    const provider = snapshot.utils.getProvider(space.network, { broviderUrl });
-    currentBlockNum = parseInt(await provider.getBlockNumber());
-  } catch {
-    return Promise.reject('unable to fetch current block number');
-  }
-
-  if (msg.payload.snapshot > currentBlockNum)
-    return Promise.reject('proposal snapshot must be in past');
-
   if (msg.payload.snapshot < networks[space.network].start)
     return Promise.reject('proposal snapshot must be after network start');
+
+  try {
+    const provider = snapshot.utils.getProvider(space.network, { broviderUrl });
+    const block = await provider.getBlock(msg.payload.snapshot);
+    if (!block) return Promise.reject('invalid snapshot block');
+  } catch (error) {
+    return Promise.reject('unable to fetch block number');
+  }
 
   try {
     const [{ dayCount, monthCount, activeProposalsByAuthor }] = await getProposalsCount(

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -179,8 +179,10 @@ export async function verify(body): Promise<any> {
     const provider = snapshot.utils.getProvider(space.network, { broviderUrl });
     const block = await provider.getBlock(msg.payload.snapshot);
     if (!block) return Promise.reject('invalid snapshot block');
-  } catch (error) {
-    return Promise.reject('unable to fetch block number');
+  } catch (error: any) {
+    if (error.message?.includes('invalid block hash or block tag'))
+      return Promise.reject('invalid snapshot block');
+    return Promise.reject('unable to fetch block');
   }
 
   try {

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -302,7 +302,7 @@ describe('writer/proposal', () => {
       msg.payload.snapshot = Number.MAX_SAFE_INTEGER;
 
       await expect(writer.verify({ ...input, msg: JSON.stringify(msg) })).rejects.toMatch(
-        'proposal snapshot must be in past'
+        'invalid snapshot block'
       );
     });
 


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot-sequencer/issues/309

## Changes :
- Will check if `snapshot` block exists on the particular network
- Previously we were checking `snapshot` with the current block

## How to test :

- Go to your proposal creation page, for example https://snapshot.org/#/thanku.eth/create?snapshot=true
- Try creating proposal with future `snapshot`
- <img width="635" alt="Untitled 2" src="https://github.com/snapshot-labs/snapshot-sequencer/assets/15967809/1f03b28e-f7e1-46e7-91cc-c50e715fba9b">
- Before: it should throw error `proposal snapshot must be in past`
- Now: it should throw error `invalid snapshot block`