### PR TITLE
fix: use keep alive for remaining fetch requests

### DIFF
--- a/src/helpers/monitoring/blockaid.ts
+++ b/src/helpers/monitoring/blockaid.ts
@@ -1,11 +1,11 @@
-import fetch from 'node-fetch';
+import { fetchWithKeepAlive } from '../utils';
 
 const BLOCKAID_API_URL = 'https://api.blockaid.io/dapp/v1/scan';
 const BLOCKAID_API_KEY = process.env.BLOCKAID_API_KEY || '';
 
 export async function scan(url: string) {
   if (!BLOCKAID_API_KEY) return { is_malicious: false };
-  const res = await fetch(BLOCKAID_API_URL, {
+  const res = await fetchWithKeepAlive(BLOCKAID_API_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/helpers/monitoring/chainpatrol.ts
+++ b/src/helpers/monitoring/chainpatrol.ts
@@ -1,11 +1,11 @@
-import fetch from 'node-fetch';
+import { fetchWithKeepAlive } from '../utils';
 
 const CHAINPATROL_API_URL = 'https://app.chainpatrol.io/api/v2/asset/check';
 const CHAINPATROL_API_KEY = process.env.CHAINPATROL_API_KEY || '';
 
 export async function scan(url: string) {
   if (!CHAINPATROL_API_KEY) return { is_malicious: false };
-  const res = await fetch(CHAINPATROL_API_URL, {
+  const res = await fetchWithKeepAlive(CHAINPATROL_API_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/helpers/shutter.ts
+++ b/src/helpers/shutter.ts
@@ -1,10 +1,9 @@
 import express from 'express';
 import { randomBytes } from 'crypto';
-import fetch from 'node-fetch';
 import { init, decrypt } from '@shutter-network/shutter-crypto';
 import { arrayify } from '@ethersproject/bytes';
 import { toUtf8String } from '@ethersproject/strings';
-import { getIp, jsonParse, rpcError, rpcSuccess } from './utils';
+import { fetchWithKeepAlive, getIp, jsonParse, rpcError, rpcSuccess } from './utils';
 import { updateProposalAndVotes } from '../scores';
 import db from './mysql';
 import log from './log';
@@ -51,7 +50,7 @@ export async function rpcRequest(method, params, url: string = SHUTTER_URL) {
       id: randomBytes(6).toString('hex')
     })
   };
-  const res = await fetch(url, init);
+  const res = await fetchWithKeepAlive(url, init);
   const { result } = await res.json();
   return result;
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Some fetch requests are not using `keepAlive`, such as shutter decryption or chain patrol monitoring.

These requests benefit from `keepAlive`, as they're sending multiple requests at the same time, and will fix the `EAI_AGAIN` network error

Closes #326 
Closes [SNAPSHOT-SEQUENCER-26](https://snapshot-labs.sentry.io/issues/4522580880/?referrer=github_integration)

## 💊 Fixes / Solution

Use `keepAlive` for all fetch requests

## 🚧 Changes

- Replace all node-fetch `fetch` requests by the custom `fetchWithKeelAlive` helper function

## 🛠️ Tests

