### PR TITLE
fix: Update testnet space limit to be same as verified spaces

### DIFF
--- a/src/helpers/limits.ts
+++ b/src/helpers/limits.ts
@@ -1,3 +1,5 @@
+const SNAPSHOT_ENV = process.env.NETWORK || 'testnet';
+
 export const FLAGGED_SPACE_PROPOSAL_DAY_LIMIT = 1;
 export const FLAGGED_SPACE_PROPOSAL_MONTH_LIMIT = 5;
 
@@ -39,7 +41,7 @@ export function getSpaceLimits(space): number[] {
     return [TURBO_SPACE_PROPOSAL_DAY_LIMIT, TURBO_SPACE_PROPOSAL_MONTH_LIMIT];
   }
 
-  if (space.verified) {
+  if (space.verified || SNAPSHOT_ENV === 'testnet') {
     return [VERIFIED_SPACE_PROPOSAL_DAY_LIMIT, VERIFIED_SPACE_PROPOSAL_MONTH_LIMIT];
   }
 


### PR DESCRIPTION
Full context: https://discord.com/channels/955773041898573854/1221106380300357804/1228248728964431932

Limit for normal space on testent will be the same as verified

### How to test:
- Try creating proposals on testnet, new limit will be `20` per day and `100` per month
