### PR TITLE
fix: fix invalid `JOIN` queries due to different collation

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -60,7 +60,7 @@ export function refreshProposalsCount(spaces?: string[]) {
         (SELECT * FROM (
           SELECT COUNT(proposals.id) AS proposal_count, author, space
           FROM proposals
-          JOIN spaces ON spaces.id = proposals.space
+          JOIN spaces ON BINARY spaces.id = BINARY proposals.space
           WHERE spaces.deleted = 0
           ${spaces ? ' AND space IN (?)' : ''}
           GROUP BY author, space
@@ -78,7 +78,7 @@ export function refreshVotesCount(spaces: string[]) {
         (SELECT * FROM (
           SELECT COUNT(votes.id) AS vote_count, voter, space
           FROM votes
-          JOIN spaces ON spaces.id = votes.space
+          JOIN spaces ON BINARY spaces.id = BINARY votes.space
           WHERE spaces.deleted = 0 AND space IN (?)
           GROUP BY voter, space
         ) AS t)

--- a/src/writer/delete-proposal.ts
+++ b/src/writer/delete-proposal.ts
@@ -1,4 +1,4 @@
-import { getProposal, getSpace } from '../helpers/actions';
+import { getProposal, getSpace, refreshVotesCount } from '../helpers/actions';
 import { jsonParse } from '../helpers/utils';
 import db from '../helpers/mysql';
 
@@ -27,7 +27,13 @@ export async function action(body): Promise<void> {
     `
     DELETE FROM proposals WHERE id = ? LIMIT 1;
     DELETE FROM votes WHERE proposal = ?;
+    UPDATE leaderboard
+      SET proposal_count = proposal_count - 1
+      WHERE user = ? AND space = ?
+      LIMIT 1;
   `,
     [id, id, proposal.author, msg.space]
   );
+
+  await refreshVotesCount([msg.space]);
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Fix issue with #127 , where the storing of leaderboard data is failing due to failing query, using data from 2 tables with different encoding, resulting in following error

```
warn: [ingestor] msg validation failed (typed data): {"cause":{"code":"ER_CANT_AGGREGATE_2COLLATIONS","errno":1267,"sqlMessage":"Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,IMPLICIT) for operation '='","sqlState":"HY000","index":0,"sql":"\n      INSERT INTO leaderboard (vote_count, user, space)\n        (SELECT * FROM (\n          SELECT COUNT(votes.id) AS vote_count, voter, space\n          FROM votes\n          JOIN spaces ON spaces.id = votes.space\n          WHERE spaces.deleted = 0 AND space IN ('coinside01.eth')\n          GROUP BY voter, space\n        ) AS t)\n      ON DUPLICATE KEY UPDATE vote_count = t.vote_count\n    "},"isOperational":true,"code":"ER_CANT_AGGREGATE_2COLLATIONS","errno":1267,"sqlMessage":"Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,IMPLICIT) for operation '='","sqlState":"HY000","index":0,"sql":"\n      INSERT INTO leaderboard (vote_count, user, space)\n        (SELECT * FROM (\n          SELECT COUNT(votes.id) AS vote_count, voter, space\n          FROM votes\n          JOIN spaces ON spaces.id = votes.space\n          WHERE spaces.deleted = 0 AND space IN ('coinside01.eth')\n          GROUP BY voter, space\n        ) AS t)\n      ON DUPLICATE KEY UPDATE vote_count = t.vote_count\n    "}
```

## 💊 Fixes / Solution

This PR converts the column result to `BINARY` before comparing them, bypasing the encoding issue.

## 🚧 Changes

- Fix failing query due to encoding issue
- Revert changes in #329 

## 🛠️ Tests

- The refresh script in #127 should now work without error