### PR TITLE
fix: Throw error if choice is invalid

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -148,7 +148,13 @@ export default async function ingestor(req) {
       if (type === 'vote-string') {
         const proposal = await getProposal(message.space, message.proposal);
         if (!proposal) return Promise.reject('unknown proposal');
-        if (proposal.privacy !== 'shutter') choice = JSON.parse(message.choice);
+        if (proposal.privacy !== 'shutter') {
+          try {
+            choice = JSON.parse(message.choice);
+          } catch (e) {
+            return Promise.reject('invalid choice');
+          }
+        }
       }
 
       payload = {


### PR DESCRIPTION
### Summary:
While voting If `choice` is a string but if it contains an error we are not returning any error, and it is confusing for some users

### How to test: 
- Send a vote with invalid json in `choice`, here is an example curl:
```bash
curl --location 'http://localhost:3001' \
--header 'Content-Type: application/json' \
--data '{
    "sig": "0x",
    "data": {
        "types": {
            "Vote": [
                {
                    "name": "from",
                    "type": "address"
                },
                {
                    "name": "space",
                    "type": "string"
                },
                {
                    "name": "timestamp",
                    "type": "uint64"
                },
                {
                    "name": "proposal",
                    "type": "bytes32"
                },
                {
                    "name": "choice",
                    "type": "string"
                },
                {
                    "name": "reason",
                    "type": "string"
                },
                {
                    "name": "app",
                    "type": "string"
                },
                {
                    "name": "metadata",
                    "type": "string"
                }
            ]
        },
        "domain": {
            "name": "snapshot",
            "version": "0.1.4"
        },
        "message": {
            "app": "snapshot",
            "from": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
            "space": "gauges.aurafinance.eth",
            "choice": "{'\''76'\'': 0.15, '\''147'\'': 0.15, '\''157'\'': 0.05, '\''230'\'': 0.075, '\''94'\'': 0.025, '\''59'\'': 0.0463, '\''143'\'': 0.0213, '\''74'\'': 0.0243, '\''68'\'': 0.0444, '\''85'\'': 0.1365, '\''111'\'': 0.0272, '\''153'\'': 0.08, '\''63'\'': 0.12, '\''160'\'': 0.025, '\''161'\'': 0.025}",
            "reason": "",
            "metadata": "{}",
            "proposal": "0x959f5f4b98b6fbd521844262bc9e2ab7a46344efe823afcb8d09771a55aaab90",
            "timestamp": 1714153655
        }
    },
    "address": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
}'
```

Before fix, it will return an error like this:
<img width="395" alt="image" src="https://github.com/snapshot-labs/snapshot-sequencer/assets/15967809/6600ea87-193a-4a8a-99d2-bbde6dd3cf66">

After fix, it will return an error like this:
<img width="477" alt="image" src="https://github.com/snapshot-labs/snapshot-sequencer/assets/15967809/993bba1c-287e-4bdf-8a1b-d1e16514be11">
