### PR TITLE
fix: prevent negative leaderboard counters

### DIFF
--- a/src/writer/delete-proposal.ts
+++ b/src/writer/delete-proposal.ts
@@ -28,7 +28,7 @@ export async function action(body): Promise<void> {
     DELETE FROM proposals WHERE id = ? LIMIT 1;
     DELETE FROM votes WHERE proposal = ?;
     UPDATE leaderboard
-      SET proposal_count = proposal_count - 1
+      SET proposal_count = GREATEST(proposal_count - 1, 0)
       WHERE user = ? AND space = ?
       LIMIT 1;
   `,


### PR DESCRIPTION
Fix https://snapshot-labs.sentry.io/issues/4542214149/events/044eed1cb2954dd5a772a29ac1b23eeb/?project=4505606761152512&query=is%3Aunresolved&referrer=previous-event&statsPeriod=90d&stream_index=5

Fix MySQL error where the `proposal_count` was set to a negative number.

As SQL transactions are not used, we can not guarantee that all counters are up-to-date