### PR TITLE
refactor: improve refresh leaderboard script

### DIFF
--- a/scripts/refresh_leaderboard_counters.ts
+++ b/scripts/refresh_leaderboard_counters.ts
@@ -2,59 +2,104 @@ import 'dotenv/config';
 import db from '../src/helpers/mysql';
 import { refreshProposalsCount, refreshVotesCount } from '../src/helpers/actions';
 
-// Usage: yarn ts-node scripts/refresh_leaderboard_counters.ts --space [OPTIONAL-SPACE-ID] --pivot TIMESTAMP
+const ALLOWED_TYPES = ['proposal', 'vote'];
+
+// Usage: yarn ts-node scripts/refresh_leaderboard_counters.ts --type proposal|vote --space OPTIONAL-SPACE-ID --pivot TIMESTAMP
 async function main() {
-  let spacesFilter = '';
-  let usersFilter = '';
+  let pivot = 0;
+  const types: string[] = [];
+  const spaces: string[] = [];
 
   process.argv.forEach((arg, index) => {
     if (arg === '--space') {
       if (!process.argv[index + 1]) throw new Error('Space ID is missing');
-      console.log('Filtered by spaces.id =', process.argv[index + 1]);
-      spacesFilter = `WHERE space = '${process.argv[index + 1].trim()}'`;
+      console.log('Filtered by spaces =', process.argv[index + 1]);
+      spaces.push(process.argv[index + 1].trim());
     }
 
     if (arg === '--pivot') {
       if (!process.argv[index + 1]) throw new Error('Pivot timestamp is missing');
-      console.log('Filtered by users.created >=', process.argv[index + 1]);
-      usersFilter = `WHERE created >= ${process.argv[index + 1].trim()}`;
+      console.log('Filtered by votes.created >=', process.argv[index + 1]);
+      pivot = +process.argv[index + 1].trim();
+    }
+
+    if (arg === '--type') {
+      if (!process.argv[index + 1]) throw new Error('Type is missing');
+
+      const type = process.argv[index + 1].trim();
+      if (!ALLOWED_TYPES.includes(type)) throw new Error('Invalid type');
+
+      console.log('Filtered by type:', type);
+      types.push(type);
     }
   });
-  console.log('');
 
-  const users: { id: string; created: number }[] = await db.queryAsync(
-    `SELECT id, created FROM users ${usersFilter} ORDER BY created ASC`
+  if (!types.length) {
+    types.push('proposal', 'vote');
+  }
+
+  if (types.includes('proposal')) {
+    await processProposalsCount(spaces);
+  } else if (types.includes('vote')) {
+    await processVotesCount(spaces, pivot);
+  }
+}
+
+async function processProposalsCount(spaces: string[]) {
+  const authors = (await db.queryAsync(`SELECT distinct(author) FROM proposals`)).map(
+    author => author.author
   );
 
-  for (const userIndex in users) {
-    const { id: user, created } = users[userIndex];
-    console.log(`Processing user ${user} (${+userIndex + 1}/${users.length}) - (ts:${created})`);
+  const proposalsCountRes = await refreshProposalsCount(spaces, authors);
+  console.log(
+    ` PROPOSAL_COUNT >`,
+    `Affected: ${proposalsCountRes.affectedRows}`,
+    `Changed: ${proposalsCountRes.changedRows}`
+  );
+}
 
-    const spaces: { space: string }[] = await db.queryAsync(
-      `SELECT DISTINCT(space) FROM votes ${
-        spacesFilter || 'WHERE 1=1'
-      } AND voter = ? GROUP BY space`,
-      user
+async function processVotesCount(spaces: string[], pivot: number) {
+  console.log('Building voters list, this may take a while... (each step is 500k voters)');
+
+  const voters: Map<string, number> = new Map();
+  let index = 0;
+  let _pivot = pivot;
+
+  while (true) {
+    process.stdout.write(index % 10 === 0 ? '_' : '.');
+    const params: any[] = [_pivot];
+    if (spaces.length) params.push(spaces);
+
+    const users = await db.queryAsync(
+      `SELECT distinct(voter) as id, created FROM votes WHERE created > ?
+      ${spaces.length ? 'AND space IN (?)' : ''}
+      ORDER BY created ASC LIMIT 500000`,
+      params
     );
+    if (!users.length) break;
 
-    const proposalsCountRes = await refreshProposalsCount([], [user]);
+    _pivot = users[users.length - 1].created;
+    index += 1;
+    users.forEach(user => {
+      if (!voters.has(user.id)) {
+        voters.set(user.id, user.created);
+      }
+    });
+  }
+
+  console.log(`Found ${voters.size} unique voters`);
+
+  let i = 0;
+  for (const [voterId, ts] of voters.entries()) {
+    console.log(`Processing user ${voterId} (${+i + 1}/${voters.size}) - (pivot:${ts})`);
+
+    const votesCountRes = await refreshVotesCount(spaces, [voterId]);
     console.log(
-      ` PROPOSAL_COUNT >`,
-      `Affected: ${proposalsCountRes.affectedRows}`,
-      `Changed: ${proposalsCountRes.changedRows}`
+      ` VOTE_COUNT     >`,
+      `Affected: ${votesCountRes.affectedRows}`,
+      `Changed: ${votesCountRes.changedRows}`
     );
-
-    for (const spaceIndex in spaces) {
-      const space = spaces[spaceIndex].space;
-
-      const votesCountRes = await refreshVotesCount([space], [user]);
-      console.log(
-        ` VOTE_COUNT     >`,
-        `Affected: ${votesCountRes.affectedRows}`,
-        `Changed: ${votesCountRes.changedRows}`,
-        `- ${space}`
-      );
-    }
+    i += 1;
   }
 }
 

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -53,7 +53,20 @@ export async function getSpace(id: string, includeDeleted = false) {
   };
 }
 
-export function refreshProposalsCount(spaces?: string[]) {
+export function refreshProposalsCount(spaces?: string[], users?: string[]) {
+  const whereFilters = ['spaces.deleted = 0'];
+  const params: string[][] = [];
+
+  if (spaces?.length) {
+    whereFilters.push('space IN (?)');
+    params.push(spaces);
+  }
+
+  if (users?.length) {
+    whereFilters.push('author IN (?)');
+    params.push(users);
+  }
+
   return db.queryAsync(
     `
       INSERT INTO leaderboard (proposal_count, user, space)
@@ -61,17 +74,24 @@ export function refreshProposalsCount(spaces?: string[]) {
           SELECT COUNT(proposals.id) AS proposal_count, author, space
           FROM proposals
           JOIN spaces ON BINARY spaces.id = BINARY proposals.space
-          WHERE spaces.deleted = 0
-          ${spaces ? ' AND space IN (?)' : ''}
+          WHERE ${whereFilters.join(' AND ')}
           GROUP BY author, space
         ) AS t)
       ON DUPLICATE KEY UPDATE proposal_count = t.proposal_count
     `,
-    spaces
+    params
   );
 }
 
-export function refreshVotesCount(spaces: string[]) {
+export function refreshVotesCount(spaces: string[], users?: string[]) {
+  const whereFilters = ['spaces.deleted = 0', 'space IN (?)'];
+  const params = [spaces];
+
+  if (users?.length) {
+    whereFilters.push('voter IN (?)');
+    params.push(users);
+  }
+
   return db.queryAsync(
     `
       INSERT INTO leaderboard (vote_count, user, space)
@@ -79,11 +99,11 @@ export function refreshVotesCount(spaces: string[]) {
           SELECT COUNT(votes.id) AS vote_count, voter, space
           FROM votes
           JOIN spaces ON BINARY spaces.id = BINARY votes.space
-          WHERE spaces.deleted = 0 AND space IN (?)
+          WHERE ${whereFilters.join(' AND ')}
           GROUP BY voter, space
         ) AS t)
       ON DUPLICATE KEY UPDATE vote_count = t.vote_count
     `,
-    spaces
+    params
   );
 }

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -83,9 +83,14 @@ export function refreshProposalsCount(spaces?: string[], users?: string[]) {
   );
 }
 
-export function refreshVotesCount(spaces: string[], users?: string[]) {
-  const whereFilters = ['spaces.deleted = 0', 'space IN (?)'];
-  const params = [spaces];
+export function refreshVotesCount(spaces?: string[], users?: string[]) {
+  const whereFilters = ['spaces.deleted = 0'];
+  const params: string[][] = [];
+
+  if (spaces?.length) {
+    whereFilters.push('space IN (?)');
+    params.push(spaces);
+  }
 
   if (users?.length) {
     whereFilters.push('voter IN (?)');


### PR DESCRIPTION
This PR improves the refresh leaderboard script

## Changes

- Instead of batching the requests by spaces, it is now batched by voter, resulting in much smaller query, but with whole script taking longer due to huge number of voters
- the `pivot` arg is now about the votes created date, and not space
- Split the refresh proposals and votes into 2 actions

Refresh the proposals count with 

```
yarn ts-node scripts/refresh_leaderboard_counters.ts --type proposal
```

Refresh the votes count with 

```
yarn ts-node scripts/refresh_leaderboard_counters.ts --type vote
```

Both can be filtered by `--space` and vote have additional `pivot` (vote date)