### PR TITLE
fix: Flagged link check to handle special chars

### DIFF
--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -51,7 +51,14 @@ export default async function run() {
 export function containsFlaggedLinks(body: string): boolean {
   if (flaggedLinks.length === 0) return false;
 
-  return new RegExp(flaggedLinks.join('|'), 'i').test(body);
+  const escapedLinks = flaggedLinks.map(link =>
+    link.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/https?:\/\//, '')
+  );
+  const regex = new RegExp(
+    `(?:https?:\\/\\/)?(?:www\\.)?(${escapedLinks.join('|')})(?:[\\/\\S]*)?`,
+    'i'
+  );
+  return regex.test(body);
 }
 
 export function flagEntity({ type, action, value }) {

--- a/test/integration/helpers/moderation.test.ts
+++ b/test/integration/helpers/moderation.test.ts
@@ -53,6 +53,13 @@ describe('moderation', () => {
         );
       });
 
+      it('returns true if body contains flagged links (case insensitive)', () => {
+        expect(containsFlaggedLinks('this is a link https://A.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link https://ABC.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link HTTPS://ABC.COM')).toBe(true);
+        expect(containsFlaggedLinks('this is a link https://test.com/ABC')).toBe(true);
+      });
+
       it('returns true if body contains flagged links with other path', () => {
         expect(containsFlaggedLinks('this is a link https://a.com/abc/abc')).toBe(true);
         expect(containsFlaggedLinks('this is a link http://xyz.com/abc')).toBe(true);

--- a/test/integration/helpers/moderation.test.ts
+++ b/test/integration/helpers/moderation.test.ts
@@ -39,7 +39,7 @@ describe('moderation', () => {
 
     describe('containsFlaggedLinks()', () => {
       beforeAll(() => {
-        setData({ flaggedLinks: ['https://a.com'] });
+        setData({ flaggedLinks: ['https://a.com', 'http://xyz.com', 'abc.com', 'test.com/abc'] });
       });
 
       afterAll(() => {
@@ -48,10 +48,48 @@ describe('moderation', () => {
 
       it('returns true if body contains flagged links', () => {
         expect(containsFlaggedLinks('this is a link https://a.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link https://abc.com in this test content')).toBe(
+          true
+        );
+      });
+
+      it('returns true if body contains flagged links with other path', () => {
+        expect(containsFlaggedLinks('this is a link https://a.com/abc/abc')).toBe(true);
+        expect(containsFlaggedLinks('this is a link http://xyz.com/abc')).toBe(true);
+        expect(containsFlaggedLinks('this is a link a.com/abc')).toBe(true);
+        expect(containsFlaggedLinks('this is a link test.com/abc')).toBe(true);
+      });
+
+      it('returns false if body contains flagged links with different path than flagged path', () => {
+        expect(containsFlaggedLinks('this is a link test.com')).toBe(false);
+        expect(containsFlaggedLinks('this is a link http://test.com')).toBe(false);
+        expect(containsFlaggedLinks('this is a link http://test.com/test')).toBe(false);
+      });
+
+      it('returns true if body contains flagged links with http or https and without protocol', () => {
+        expect(containsFlaggedLinks('this is a link http://abc.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link https://abc.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link abc.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link http://a.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link https://a.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link a.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link http://xyz.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link https://xyz.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link xyz.com')).toBe(true);
+      });
+
+      it('returns true if body contains flagged links with http or https and without protocol', () => {
+        expect(containsFlaggedLinks('this is a link https://www.abc.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link http://abc.a.com')).toBe(true);
+        expect(containsFlaggedLinks('this is a link xyz.a.com')).toBe(true);
       });
 
       it('returns false if body does not contain flagged links', () => {
         expect(containsFlaggedLinks('this is a link https://b.com')).toBe(false);
+      });
+
+      it('returns false if body does not contain flagged links without special chars', () => {
+        expect(containsFlaggedLinks('this is a link https://a1com')).toBe(false);
       });
     });
 


### PR DESCRIPTION
### Summary
- [ Handle special chars ](https://discord.com/channels/955773041898573854/1221106380300357804/1237318479829405716) eg: `clcula` is matching if flaggedLinks contains `clc.la`
- Detect even if the protocol is either `http` or `https` or no protocol at all
- Detect if the link contains a subdomain, for example using `www`
- Detect if the path is anything else than flagged one
- Detect if the link is case-insensitive

### How to test
- Run `yarn test:integration` which contains all the new cases


