### PR TITLE
fix: remove deprecated goerli network from follows network

### DIFF
--- a/src/writer/follow.ts
+++ b/src/writer/follow.ts
@@ -2,7 +2,7 @@ import { FOLLOWS_LIMIT_PER_USER } from '../helpers/limits';
 import db from '../helpers/mysql';
 
 const MAINNET_NETWORK_WHITELIST = ['s', 'eth', 'matic', 'arb1', 'oeth', 'sn'];
-const TESTNET_NETWORK_WHITELIST = ['s-tn', 'gor', 'sep', 'linea-testnet', 'sn-tn', 'sn-sep'];
+const TESTNET_NETWORK_WHITELIST = ['s-tn', 'sep', 'linea-testnet', 'sn-sep'];
 
 export const getFollowsCount = async (follower: string): Promise<number> => {
   const query = `SELECT COUNT(*) AS count FROM follows WHERE follower = ?`;


### PR DESCRIPTION
Following https://github.com/snapshot-labs/sx-monorepo/pull/327 

Remove goerli from supported follows network