### PR TITLE
fix: use whitelist to validate space network

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -1,7 +1,7 @@
 import snapshot from '@snapshot-labs/snapshot.js';
 import db from './mysql';
 import { jsonParse } from './utils';
-import { defaultNetwork } from '../writer/follow';
+import { NETWORK_WHITELIST, defaultNetwork } from '../writer/follow';
 
 export async function addOrUpdateSpace(space: string, settings: any) {
   if (!settings?.name) return false;
@@ -40,7 +40,7 @@ export async function getProposal(space, id) {
 }
 
 export async function getSpace(id: string, includeDeleted = false, network = defaultNetwork) {
-  if (network !== defaultNetwork) {
+  if (NETWORK_WHITELIST.includes(network)) {
     const spaceExist = await sxSpaceExists(id);
     if (!spaceExist) return false;
 

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -40,7 +40,7 @@ export async function getProposal(space, id) {
 }
 
 export async function getSpace(id: string, includeDeleted = false, network = defaultNetwork) {
-  if (NETWORK_WHITELIST.includes(network)) {
+  if (NETWORK_WHITELIST.includes(network) && network !== defaultNetwork) {
     const spaceExist = await sxSpaceExists(id);
     if (!spaceExist) return false;
 

--- a/src/writer/follow.ts
+++ b/src/writer/follow.ts
@@ -3,6 +3,7 @@ import db from '../helpers/mysql';
 
 const MAINNET_NETWORK_WHITELIST = ['s', 'eth', 'matic', 'arb1', 'oeth', 'sn'];
 const TESTNET_NETWORK_WHITELIST = ['s-tn', 'gor', 'sep', 'linea-testnet', 'sn-tn', 'sn-sep'];
+export const NETWORK_WHITELIST = [...MAINNET_NETWORK_WHITELIST, ...TESTNET_NETWORK_WHITELIST];
 
 export const getFollowsCount = async (follower: string): Promise<number> => {
   const query = `SELECT COUNT(*) AS count FROM follows WHERE follower = ?`;

--- a/test/fixtures/space.ts
+++ b/test/fixtures/space.ts
@@ -35,6 +35,24 @@ export const spacesSqlFixtures: Record<string, any>[] = [
       network: '1',
       strategies: [{ name: 'basic' }]
     }
+  },
+  {
+    id: 'test-deleted.eth',
+    name: 'Test deleted space',
+    verified: 0,
+    flagged: 0,
+    deleted: 1,
+    hibernated: 0,
+    turbo: 0,
+    created: 1649844547,
+    updated: 1649844547,
+    settings: {
+      name: 'Test deleted space',
+      admins: ['0x87D68ecFBcF53c857ABf494728Cf3DE1016b27B0'],
+      symbol: 'TEST2',
+      network: '1',
+      strategies: [{ name: 'basic' }]
+    }
   }
 ];
 

--- a/test/integration/helpers/actions.test.ts
+++ b/test/integration/helpers/actions.test.ts
@@ -1,5 +1,6 @@
 import { getSpace, sxSpaceExists } from '../../../src/helpers/actions';
 import db, { sequencerDB } from '../../../src/helpers/mysql';
+import { defaultNetwork } from '../../../src/writer/follow';
 import { spacesSqlFixtures } from '../../fixtures/space';
 
 describe('helpers/actions', () => {
@@ -8,104 +9,97 @@ describe('helpers/actions', () => {
     await sequencerDB.endAsync();
   });
 
+  const expectedSpace = {
+    verified: true,
+    flagged: false,
+    deleted: false,
+    hibernated: false,
+    turbo: false,
+    name: 'Test Space',
+    admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
+    symbol: 'TEST',
+    network: '1',
+    strategies: [{ name: 'basic' }]
+  };
+
+  const expectedDeletedSpace = {
+    name: 'Test deleted space',
+    verified: false,
+    flagged: false,
+    deleted: true,
+    hibernated: false,
+    turbo: false,
+    admins: ['0x87D68ecFBcF53c857ABf494728Cf3DE1016b27B0'],
+    symbol: 'TEST2',
+    network: '1',
+    strategies: [{ name: 'basic' }]
+  };
+
   describe('getSpace()', () => {
-    beforeEach(async () => {
-      const spaces = spacesSqlFixtures.map(space => ({
-        ...space,
-        settings: JSON.stringify(space.settings)
-      }));
-      await db.queryAsync('INSERT INTO snapshot_sequencer_test.spaces SET ?', spaces);
+    beforeAll(async () => {
+      await Promise.all(
+        spacesSqlFixtures.map(space => {
+          const values = {
+            ...space,
+            settings: JSON.stringify(space.settings)
+          };
+          return db.queryAsync('INSERT INTO snapshot_sequencer_test.spaces SET ?', values);
+        })
+      );
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
       await db.queryAsync('DELETE FROM snapshot_sequencer_test.spaces');
     });
 
     describe('for snapshot space', () => {
       it('returns the space for the given ID', () => {
-        expect(getSpace('test.eth')).resolves.toEqual({
-          verified: true,
-          flagged: false,
-          deleted: false,
-          hibernated: false,
-          turbo: false,
-          name: 'Test Space',
-          admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
-          symbol: 'TEST',
-          network: '1',
-          strategies: [{ name: 'basic' }]
-        });
+        return expect(getSpace('test.eth')).resolves.toEqual(expectedSpace);
       });
 
-      it('returns the space for the given ID with network', () => {
-        expect(getSpace('test.eth', false, 's')).resolves.toEqual({
-          verified: true,
-          flagged: false,
-          deleted: false,
-          hibernated: false,
-          turbo: false,
-          name: 'Test Space',
-          admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
-          symbol: 'TEST',
-          network: '1',
-          strategies: [{ name: 'basic' }]
-        });
+      it('returns the space for the given ID with a valid network', () => {
+        return expect(getSpace('test.eth', false, defaultNetwork)).resolves.toEqual(expectedSpace);
       });
 
-      it('does not return deleted space by default', async () => {
-        await db.queryAsync(
-          'UPDATE snapshot_sequencer_test.spaces SET deleted = 1 WHERE id = ? LIMIT 1',
-          ['test.eth']
-        );
-        expect(getSpace('test.eth')).resolves.toBe(false);
+      it('returns a snapshot space for the given ID with an invalid network', () => {
+        return expect(getSpace('test.eth', false, 'hello-world')).resolves.toEqual(expectedSpace);
       });
 
-      it('returns deleted space when asked', async () => {
-        await db.queryAsync(
-          'UPDATE snapshot_sequencer_test.spaces SET deleted = 1 WHERE id = ? LIMIT 1',
-          ['test.eth']
-        );
-        expect(getSpace('test.eth', true)).resolves.toEqual({
-          verified: true,
-          flagged: false,
-          deleted: true,
-          hibernated: false,
-          turbo: false,
-          name: 'Test Space',
-          admins: ['0xFC01614d28595d9ea5963daD9f44C0E0F0fE10f0'],
-          symbol: 'TEST',
-          network: '1',
-          strategies: [{ name: 'basic' }]
-        });
+      it('does not return deleted space by default', () => {
+        return expect(getSpace('test-deleted.eth')).resolves.toBe(false);
+      });
+
+      it('returns deleted space when asked', () => {
+        return expect(getSpace('test-deleted.eth', true)).resolves.toEqual(expectedDeletedSpace);
       });
 
       it('returns false when no space is found', () => {
-        expect(getSpace('test-space.eth')).resolves.toBe(false);
+        return expect(getSpace('test-space.eth')).resolves.toBe(false);
       });
     });
 
     describe('for sx spaces', () => {
       it('returns the space for the given ID', () => {
-        expect(
+        return expect(
           getSpace('0xaeee929Ca508Dd1F185a8E74F4a9c37c25595c25', false, 'eth')
         ).resolves.toEqual({
-          network: 1
+          network: 0
         });
       });
 
       it('returns false when the space does not exist', () => {
-        expect(getSpace('not-existing-space-id', false, 'eth')).resolves.toBe(false);
+        return expect(getSpace('not-existing-space-id', false, 'eth')).resolves.toBe(false);
       });
     });
   });
 
   describe('sxSpaceExists()', () => {
-    it('returns the space id when it exists', async () => {
+    it('returns true when it exists', async () => {
       const id = '0xaeee929Ca508Dd1F185a8E74F4a9c37c25595c25';
       return expect(sxSpaceExists(id)).resolves.toEqual(true);
     });
 
-    it('returns null when it does not exist', async () => {
+    it('returns false when it does not exist', async () => {
       const id = 'not-existing-space-id';
       return expect(sxSpaceExists(id)).resolves.toEqual(false);
     });

--- a/test/integration/writer/proposal.test.ts
+++ b/test/integration/writer/proposal.test.ts
@@ -48,7 +48,7 @@ describe('writer/proposal', () => {
         await expect(action(input, 'ipfs', 'receipt', id)).resolves.toBeUndefined();
 
         const [proposal] = await db.queryAsync('SELECT * FROM proposals WHERE id = ?', [id]);
-        expect(proposal.flagged).toBe(1);
+        return expect(proposal.flagged).toBe(1);
       });
     });
 
@@ -59,7 +59,7 @@ describe('writer/proposal', () => {
         await expect(action(input, 'ipfs', 'receipt', id)).resolves.toBeUndefined();
 
         const [proposal] = await db.queryAsync('SELECT * FROM proposals WHERE id = ?', [id]);
-        expect(proposal.flagged).toBe(0);
+        return expect(proposal.flagged).toBe(0);
       });
     });
   });


### PR DESCRIPTION
This PR uses a whitelist to validate the `network` argument, and will check for sx space only if it's a valid SX network, compared to before, where it would consider all non-default-network as SX network.

This PR will fix an issue where people are still trying to pass the `network` params when creating a proposal