### PR TITLE
fix: Add back leaderboard update queries

### DIFF
--- a/src/writer/delete-proposal.ts
+++ b/src/writer/delete-proposal.ts
@@ -20,13 +20,23 @@ export async function verify(body): Promise<any> {
 
 export async function action(body): Promise<void> {
   const msg = jsonParse(body.msg);
+  const proposal = await getProposal(msg.space, msg.payload.proposal);
+  const voters = await db.queryAsync(`SELECT voter FROM votes WHERE proposal = ?`, [
+    msg.payload.proposal
+  ]);
   const id = msg.payload.proposal;
 
   await db.queryAsync(
     `
     DELETE FROM proposals WHERE id = ? LIMIT 1;
     DELETE FROM votes WHERE proposal = ?;
+    UPDATE leaderboard
+      SET proposal_count = GREATEST(proposal_count - 1, 0)
+      WHERE user = ? AND space = ?
+      LIMIT 1;
+    UPDATE leaderboard SET vote_count = GREATEST(vote_count - 1, 0)
+      WHERE user IN (?) AND space = ?;
   `,
-    [id, id]
+    [id, id, proposal.author, msg.space, voters.map(voter => voter.voter), msg.space]
   );
 }

--- a/src/writer/delete-space.ts
+++ b/src/writer/delete-space.ts
@@ -27,9 +27,10 @@ export async function action(body): Promise<void> {
   try {
     const query = `
       UPDATE spaces SET deleted = 1 WHERE id = ? LIMIT 1;
+      DELETE FROM leaderboard WHERE space = ?;
     `;
 
-    await db.queryAsync(query, [space]);
+    await db.queryAsync(query, [space, space]);
   } catch (e) {
     capture(e, { space });
     log.warn('[writer] Failed to store settings', space, e);

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -252,7 +252,10 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
 
   const query = `
     INSERT INTO proposals SET ?;
+    INSERT INTO leaderboard (space, user, proposal_count)
+    VALUES(?, ?, 1)
+    ON DUPLICATE KEY UPDATE proposal_count = proposal_count + 1
   `;
 
-  await db.queryAsync(query, [proposal]);
+  await db.queryAsync(query, [proposal, space, author]);
 }

--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -156,6 +156,7 @@ export async function action(body, ipfs, receipt, id, context): Promise<void> {
       UPDATE votes
       SET id = ?, ipfs = ?, created = ?, choice = ?, reason = ?, metadata = ?, app = ?, vp = ?, vp_by_strategy = ?, vp_state = ?
       WHERE voter = ? AND proposal = ? AND space = ?;
+      UPDATE leaderboard SET last_vote = ? WHERE user = ? AND space = ? LIMIT 1;
     `,
       [
         id,
@@ -170,6 +171,9 @@ export async function action(body, ipfs, receipt, id, context): Promise<void> {
         params.vp_state,
         voter,
         proposalId,
+        msg.space,
+        created,
+        voter,
         msg.space
       ]
     );
@@ -178,8 +182,11 @@ export async function action(body, ipfs, receipt, id, context): Promise<void> {
     await db.queryAsync(
       `
         INSERT INTO votes SET ?;
+        INSERT INTO leaderboard (space, user, vote_count, last_vote)
+          VALUES(?, ?, 1, ?)
+          ON DUPLICATE KEY UPDATE vote_count = vote_count + 1, last_vote = ?
       `,
-      [params]
+      [params, msg.space, voter, created, created]
     );
   }
 


### PR DESCRIPTION
This is just adding back https://github.com/snapshot-labs/snapshot-sequencer/pull/358/files and update delete proposal to reduce count of proposal voters instead of refresh 