### PR TITLE
fix: ignore 504 errors from score-api

### DIFF
--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -66,7 +66,7 @@ export async function verify(body): Promise<any> {
       );
       if (!validate) return Promise.reject('failed vote validation');
     } catch (e) {
-      capture(e, { contexts: { input: { space: msg.space, address: body.address } } });
+      captureError(e, { contexts: { input: { space: msg.space, address: body.address } } }, [504]);
       log.warn(
         `[writer] Failed to check vote validation, ${msg.space}, ${body.address}, ${JSON.stringify(
           e

--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -5,7 +5,6 @@ import { getProposal } from '../helpers/actions';
 import db from '../helpers/mysql';
 import { updateProposalAndVotes } from '../scores';
 import log from '../helpers/log';
-import { capture } from '@snapshot-labs/snapshot-sentry';
 
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
 


### PR DESCRIPTION
Following this https://github.com/snapshot-labs/snapshot-sequencer/pull/359

Ignore 504 errors from missed validation