### PR TITLE
fix: use correct SX API for different network

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -41,7 +41,7 @@ export async function getProposal(space, id) {
 
 export async function getSpace(id: string, includeDeleted = false, network = defaultNetwork) {
   if (NETWORK_WHITELIST.includes(network) && network !== defaultNetwork) {
-    const spaceExist = await sxSpaceExists(id);
+    const spaceExist = await sxSpaceExists(network, id);
     if (!spaceExist) return false;
 
     return {
@@ -64,18 +64,27 @@ export async function getSpace(id: string, includeDeleted = false, network = def
   };
 }
 
-export async function sxSpaceExists(spaceId: string): Promise<boolean> {
-  const { space } = await snapshot.utils.subgraphRequest(
-    'https://api.studio.thegraph.com/query/23545/sx/version/latest',
-    {
-      space: {
-        __args: {
-          id: spaceId
-        },
-        id: true
-      }
+export async function sxSpaceExists(network: string, spaceId: string): Promise<boolean> {
+  const urls = {
+    eth: 'https://api.studio.thegraph.com/query/23545/sx/version/latest',
+    sep: 'https://api.studio.thegraph.com/query/23545/sx-sepolia/version/latest',
+    matic: 'https://api.studio.thegraph.com/query/23545/sx-polygon/version/latest',
+    arb1: 'https://api.studio.thegraph.com/query/23545/sx-arbitrum/version/latest',
+    oeth: 'https://api.studio.thegraph.com/query/23545/sx-optimism/version/latest',
+    sn: 'https://api-1.snapshotx.xyz',
+    'sn-sep': 'https://testnet-api-1.snapshotx.xyz',
+    'linea-testnet':
+      'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/snapshot-labs/sx-subgraph'
+  };
+
+  const { space } = await snapshot.utils.subgraphRequest(urls[network], {
+    space: {
+      __args: {
+        id: spaceId
+      },
+      id: true
     }
-  );
+  });
   return !!space?.id;
 }
 

--- a/test/integration/helpers/actions.test.ts
+++ b/test/integration/helpers/actions.test.ts
@@ -94,14 +94,20 @@ describe('helpers/actions', () => {
   });
 
   describe('sxSpaceExists()', () => {
-    it('returns true when it exists', async () => {
-      const id = '0xaeee929Ca508Dd1F185a8E74F4a9c37c25595c25';
-      return expect(sxSpaceExists(id)).resolves.toEqual(true);
+    const mapping = {
+      sn: '0x001080f1ced38269d7a32068700179c6335dee568f8599cf74b120869f8ec641',
+      arb1: '0xFd36252770642Ac48FC3A06d7A1D00be8946dd18',
+      oeth: '0x82572911308D2579f15e3cF21402Dcf1D5408300',
+      matic: '0x80D0Ffd8739eABF16436074fF64DC081c60C833A',
+      eth: '0xaeee929Ca508Dd1F185a8E74F4a9c37c25595c25'
+    };
+
+    it.each(Object.entries(mapping))('returns true when it exists for %s', async (network, id) => {
+      return expect(sxSpaceExists(network, id)).resolves.toEqual(true);
     });
 
     it('returns false when it does not exist', async () => {
-      const id = 'not-existing-space-id';
-      return expect(sxSpaceExists(id)).resolves.toEqual(false);
+      return expect(sxSpaceExists('sep', mapping['eth'])).resolves.toEqual(false);
     });
   });
 });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The SX API we're currently using to check and validate onchain spaces on Follow actions is only for a single type of network

## 💊 Fixes / Solution

Fix #355 

Use correct SX API, for each different network types

## 🚧 Changes

- Use a list of different SX API, for each network, like on stamp https://github.com/snapshot-labs/stamp/blob/master/src/resolvers/space-sx.ts

## 🛠️ Tests

- Run `yarn test`