### PR TITLE
fix: Check for split-delegation strategy with delegationOverride

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -75,13 +75,10 @@ export function hasStrategyOverride(strategies: any[]) {
   if (keywords.some(keyword => strategiesStr.includes(`"name":${keyword}`))) return true;
   // Check for split-delegation with delegationOverride
   const splitDelegation = strategies.filter(strategy => strategy.name === 'split-delegation');
-  if (
+  return (
     splitDelegation.length > 0 &&
     splitDelegation.some(strategy => strategy.params?.delegationOverride)
   )
-    return true;
-
-  return false;
 }
 
 export function validateChoices({ type, choices }): boolean {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -72,7 +72,16 @@ export function hasStrategyOverride(strategies: any[]) {
     '"api-v2-override"'
   ];
   const strategiesStr = JSON.stringify(strategies).toLowerCase();
-  return keywords.some(keyword => strategiesStr.includes(`"name":${keyword}`));
+  if (keywords.some(keyword => strategiesStr.includes(`"name":${keyword}`))) return true;
+  // Check for split-delegation with delegationOverride
+  const splitDelegation = strategies.filter(strategy => strategy.name === 'split-delegation');
+  if (
+    splitDelegation.length > 0 &&
+    splitDelegation.some(strategy => strategy.params?.delegationOverride)
+  )
+    return true;
+
+  return false;
 }
 
 export function validateChoices({ type, choices }): boolean {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -78,7 +78,7 @@ export function hasStrategyOverride(strategies: any[]) {
   return (
     splitDelegation.length > 0 &&
     splitDelegation.some(strategy => strategy.params?.delegationOverride)
-  )
+  );
 }
 
 export function validateChoices({ type, choices }): boolean {


### PR DESCRIPTION
### Summary
This PR is to enable vote overriding for `split-delegation` strategy https://github.com/snapshot-labs/snapshot-strategies/pull/1484 If `delegationOverride` is `true`


### How to test:
- Create a proposal by enabling `split-delegation` strategy on your space with `delegationOverride` param as `true`
- User should be able to override their vote

