### PR TITLE
fix: enforce lowercase space ID

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -12,7 +12,7 @@ export async function addOrUpdateSpace(space: string, settings: any) {
 
   await db.queryAsync(query, [
     {
-      id: space,
+      id: space.toLowerCase(),
       name: settings.name,
       created: ts,
       updated: ts,
@@ -49,7 +49,7 @@ export async function getSpace(id: string, includeDeleted = false, network = def
     };
   }
 
-  const query = `SELECT settings, deleted, flagged, verified, turbo, hibernated FROM spaces WHERE id = ? AND deleted in (?) LIMIT 1`;
+  const query = `SELECT settings, deleted, flagged, verified, turbo, hibernated FROM spaces WHERE LOWER(id) = LOWER(?) AND deleted in (?) LIMIT 1`;
   const spaces = await db.queryAsync(query, [id, includeDeleted ? [0, 1] : [0]]);
 
   if (!spaces[0]) return false;

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -49,8 +49,8 @@ export async function getSpace(id: string, includeDeleted = false, network = def
     };
   }
 
-  const query = `SELECT settings, deleted, flagged, verified, turbo, hibernated FROM spaces WHERE LOWER(id) = LOWER(?) AND deleted in (?) LIMIT 1`;
-  const spaces = await db.queryAsync(query, [id, includeDeleted ? [0, 1] : [0]]);
+  const query = `SELECT settings, deleted, flagged, verified, turbo, hibernated FROM spaces WHERE id = ? AND deleted in (?) LIMIT 1`;
+  const spaces = await db.queryAsync(query, [id.toLowerCase(), includeDeleted ? [0, 1] : [0]]);
 
   if (!spaces[0]) return false;
 

--- a/test/integration/helpers/actions.test.ts
+++ b/test/integration/helpers/actions.test.ts
@@ -57,6 +57,10 @@ describe('helpers/actions', () => {
         return expect(getSpace('test.eth')).resolves.toEqual(expectedSpace);
       });
 
+      it('returns the space (case-insensitive) for the given ID', () => {
+        return expect(getSpace('TEST.eth')).resolves.toEqual(expectedSpace);
+      });
+
       it('returns the space for the given ID with a valid network', () => {
         return expect(getSpace('test.eth', false, defaultNetwork)).resolves.toEqual(expectedSpace);
       });


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot-hub/issues/448

This PR enforce that:

- Space ID is always lower case on space creation
- Checking for space existence is case insensitive, so `a.eth` and `A.eth` are equal (this is already the case with the current table collation, will be more useful once we moved to the new case sensitive collation)