### PR TITLE
feat: clear stamp cache on data update

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -12,7 +12,7 @@ export async function addOrUpdateSpace(space: string, settings: any) {
 
   await db.queryAsync(query, [
     {
-      id: space.toLowerCase(),
+      id: space,
       name: settings.name,
       created: ts,
       updated: ts,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -194,3 +194,9 @@ export function captureError(e: any, context?: any, ignoredErrorCodes?: number[]
 
   capture(e, context);
 }
+
+export function clearStampCache(type: string, id: string): boolean {
+  fetch(`https://cdn.stamp.fyi/clear/${type}/eth:${id}`);
+
+  return true;
+}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -195,8 +195,6 @@ export function captureError(e: any, context?: any, ignoredErrorCodes?: number[]
   capture(e, context);
 }
 
-export function clearStampCache(type: string, id: string): boolean {
-  fetch(`https://cdn.stamp.fyi/clear/${type}/eth:${id}`);
-
-  return true;
+export function clearStampCache(type: string, id: string) {
+  fetch(`https://cdn.stamp.fyi/clear/${type}/${type === 'avatar' ? 'eth:' : ''}${id}`);
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -195,6 +195,6 @@ export function captureError(e: any, context?: any, ignoredErrorCodes?: number[]
   capture(e, context);
 }
 
-export function clearStampCache(type: string, id: string) {
-  fetch(`https://cdn.stamp.fyi/clear/${type}/${type === 'avatar' ? 'eth:' : ''}${id}`);
+export async function clearStampCache(type: string, id: string) {
+  return fetch(`https://cdn.stamp.fyi/clear/${type}/${type === 'avatar' ? 'eth:' : ''}${id}`);
 }

--- a/src/writer/profile.ts
+++ b/src/writer/profile.ts
@@ -30,5 +30,5 @@ export async function action(message, ipfs): Promise<void> {
 
   await db.queryAsync('REPLACE INTO users SET ?', params);
 
-  if (profile.avatar !== existingProfile.avatar) clearStampCache('avatar', message.from);
+  if (profile.avatar !== existingProfile.avatar) await clearStampCache('avatar', message.from);
 }

--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -103,5 +103,5 @@ export async function action(body): Promise<void> {
     return Promise.reject('failed store settings');
   }
 
-  if (existingSettings.avatar !== msg.payload.avatar) clearStampCache('space', space);
+  if (existingSettings.avatar !== msg.payload.avatar) await clearStampCache('space', space);
 }

--- a/test/unit/writer/profile.test.ts
+++ b/test/unit/writer/profile.test.ts
@@ -1,5 +1,56 @@
+import db from '../../../src/helpers/mysql';
+import { action } from '../../../src/writer/profile';
+import * as utils from '../../../src/helpers/utils';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('writer/profile', () => {
   describe('verify()', () => {
     it.todo('rejects if the schema is invalid');
+  });
+
+  describe('action()', () => {
+    const userProfile = {
+      name: 'Test name',
+      avatar: 'https://snapshot.org',
+      about: 'Bio',
+      twitter: '',
+      github: ''
+    };
+
+    beforeAll(async () => {
+      await db.queryAsync('INSERT INTO users SET ?', [
+        { id: '0x0', ipfs: '0', created: 0, profile: JSON.stringify(userProfile) }
+      ]);
+    });
+
+    afterAll(async () => {
+      await db.queryAsync('DELETE FROM users WHERE id = ?', ['0x0']);
+    });
+
+    it('clears the stamp cache if the avatar has changed', async () => {
+      const spy = jest.spyOn(utils, 'clearStampCache');
+
+      await action(
+        { profile: JSON.stringify({ avatar: 'https://newurl.com' }), timestamp: 0, from: '0x0' },
+
+        '1'
+      );
+
+      return expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not clear the stamp cache if the avatar has not changed', () => {
+      const spy = jest.spyOn(utils, 'clearStampCache');
+
+      action(
+        { profile: JSON.stringify({ avatar: userProfile.avatar }), timestamp: 0, from: '0x0' },
+        '2'
+      );
+
+      return expect(spy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Related to https://discord.com/channels/955773041898573854/1031838169282392144/1249097030094291066

This PR will call stamp service and clear the relevant cache on avatar update

Cache will be cleared when updating:

- user's avatar
- spaces' avatar