### PR TITLE
fix: fix missing value for updated column

### DIFF
--- a/src/writer/statement.ts
+++ b/src/writer/statement.ts
@@ -25,7 +25,8 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     space,
     about: msg.payload.about,
     statement: msg.payload.statement,
-    created
+    created,
+    updated: created
   };
 
   const query =


### PR DESCRIPTION
When trying to create a new statement, the query is failing with `ER_NO_DEFAULT_FOR_FIELD ` error, due to the `updated` field not having a default value

This PR set a default value when inserting a new statement