### PR TITLE
fix: Increase statements id length

### DIFF
--- a/test/schema.sql
+++ b/test/schema.sql
@@ -147,7 +147,7 @@ CREATE TABLE users (
 );
 
 CREATE TABLE statements (
-  id VARCHAR(64) NOT NULL,
+  id VARCHAR(66) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
   delegate VARCHAR(64) NOT NULL,
   space VARCHAR(64) NOT NULL,


### PR DESCRIPTION
Change the length of the `id` field in statements to be the same as other tables