### PR TITLE
feat: support new statement properties

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -1,7 +1,6 @@
 import snapshot from '@snapshot-labs/snapshot.js';
 import db from './mysql';
-import { jsonParse } from './utils';
-import { NETWORK_WHITELIST, defaultNetwork } from '../writer/follow';
+import { DEFAULT_NETWORK_ID, NETWORK_ID_WHITELIST, jsonParse } from './utils';
 
 export async function addOrUpdateSpace(space: string, settings: any) {
   if (!settings?.name) return false;
@@ -39,8 +38,8 @@ export async function getProposal(space, id) {
   return proposal;
 }
 
-export async function getSpace(id: string, includeDeleted = false, network = defaultNetwork) {
-  if (NETWORK_WHITELIST.includes(network) && network !== defaultNetwork) {
+export async function getSpace(id: string, includeDeleted = false, network = DEFAULT_NETWORK_ID) {
+  if (NETWORK_ID_WHITELIST.includes(network) && network !== DEFAULT_NETWORK_ID) {
     const spaceExist = await sxSpaceExists(network, id);
     if (!spaceExist) return false;
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -9,8 +9,18 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { BigNumber } from '@ethersproject/bignumber';
 
+const MAINNET_NETWORK_ID_WHITELIST = ['s', 'eth', 'matic', 'arb1', 'oeth', 'sn'];
+const TESTNET_NETWORK_ID_WHITELIST = ['s-tn', 'sep', 'linea-testnet', 'sn-sep'];
+const broviderUrl = process.env.BROVIDER_URL ?? 'https://rpc.snapshot.org';
+
+export const NETWORK_ID_WHITELIST = [
+  ...MAINNET_NETWORK_ID_WHITELIST,
+  ...TESTNET_NETWORK_ID_WHITELIST
+];
 export const DEFAULT_NETWORK = process.env.DEFAULT_NETWORK ?? '1';
-const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
+export const NETWORK_IDS =
+  process.env.NETWORK === 'testnet' ? TESTNET_NETWORK_ID_WHITELIST : MAINNET_NETWORK_ID_WHITELIST;
+export const DEFAULT_NETWORK_ID = NETWORK_IDS[0];
 
 export function jsonParse(input, fallback?) {
   try {
@@ -21,7 +31,7 @@ export function jsonParse(input, fallback?) {
 }
 
 export function sendError(res: Response, description: any, status?: number) {
-  const statusCode = status || (typeof description === 'string' ? 400 : 500);
+  const statusCode = status ?? (typeof description === 'string' ? 400 : 500);
   return res.status(statusCode).json({
     error: statusCode < 500 ? 'client_error' : 'server_error',
     error_description: description

--- a/src/writer/follow.ts
+++ b/src/writer/follow.ts
@@ -1,9 +1,6 @@
-import { FOLLOWS_LIMIT_PER_USER } from '../helpers/limits';
 import db from '../helpers/mysql';
-
-const MAINNET_NETWORK_WHITELIST = ['s', 'eth', 'matic', 'arb1', 'oeth', 'sn'];
-const TESTNET_NETWORK_WHITELIST = ['s-tn', 'sep', 'linea-testnet', 'sn-sep'];
-export const NETWORK_WHITELIST = [...MAINNET_NETWORK_WHITELIST, ...TESTNET_NETWORK_WHITELIST];
+import { FOLLOWS_LIMIT_PER_USER } from '../helpers/limits';
+import { DEFAULT_NETWORK_ID, NETWORK_IDS } from '../helpers/utils';
 
 export const getFollowsCount = async (follower: string): Promise<number> => {
   const query = `SELECT COUNT(*) AS count FROM follows WHERE follower = ?`;
@@ -13,10 +10,6 @@ export const getFollowsCount = async (follower: string): Promise<number> => {
   return count;
 };
 
-export const networks =
-  process.env.NETWORK === 'testnet' ? TESTNET_NETWORK_WHITELIST : MAINNET_NETWORK_WHITELIST;
-export const defaultNetwork = networks[0];
-
 export async function verify(message): Promise<any> {
   const count = await getFollowsCount(message.from);
 
@@ -24,7 +17,7 @@ export async function verify(message): Promise<any> {
     return Promise.reject(`you can join max ${FOLLOWS_LIMIT_PER_USER} spaces`);
   }
 
-  if (message.network && !networks.includes(message.network)) {
+  if (message.network && !NETWORK_IDS.includes(message.network)) {
     return Promise.reject(`network ${message.network} is not allowed`);
   }
 
@@ -37,7 +30,7 @@ export async function action(message, ipfs, receipt, id): Promise<void> {
     ipfs,
     follower: message.from,
     space: message.space,
-    network: message.network || defaultNetwork,
+    network: message.network || DEFAULT_NETWORK_ID,
     created: message.timestamp
   };
 

--- a/src/writer/statement.ts
+++ b/src/writer/statement.ts
@@ -1,7 +1,7 @@
 import snapshot from '@snapshot-labs/snapshot.js';
 import db from '../helpers/mysql';
-import { jsonParse } from '../helpers/utils';
 import log from '../helpers/log';
+import { DEFAULT_NETWORK_ID, NETWORK_IDS, jsonParse } from '../helpers/utils';
 
 export async function verify(body): Promise<any> {
   const msg = jsonParse(body.msg, {});
@@ -10,6 +10,11 @@ export async function verify(body): Promise<any> {
     log.warn(`[writer] Wrong statement format ${JSON.stringify(schemaIsValid)}`);
     return Promise.reject('wrong statement format');
   }
+
+  if (msg.payload.network && !NETWORK_IDS.includes(msg.payload.network)) {
+    return Promise.reject(`network ${msg.payload.network} is not allowed`);
+  }
+
   return true;
 }
 
@@ -23,13 +28,24 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     ipfs,
     delegate,
     space,
+    network: msg.payload.network || DEFAULT_NETWORK_ID,
     about: msg.payload.about,
     statement: msg.payload.statement,
+    discourse: msg.payload.discourse || '',
+    status: msg.payload.status || 'inactive',
     created
   };
 
   const query =
-    'INSERT INTO statements SET ? ON DUPLICATE KEY UPDATE ipfs = ?, about = ?, statement = ?, updated = ?';
-  const params = [item, item.ipfs, item.about, item.statement, item.created];
+    'INSERT INTO statements SET ? ON DUPLICATE KEY UPDATE ipfs = ?, about = ?, statement = ?, discourse = ?, status = ?, updated = ?';
+  const params = [
+    item,
+    item.ipfs,
+    item.about,
+    item.statement,
+    item.discourse,
+    item.status,
+    item.created
+  ];
   await db.queryAsync(query, params);
 }

--- a/src/writer/unfollow.ts
+++ b/src/writer/unfollow.ts
@@ -1,5 +1,5 @@
 import db from '../helpers/mysql';
-import { defaultNetwork } from './follow';
+import { DEFAULT_NETWORK_ID } from '../helpers/utils';
 
 export async function verify(): Promise<any> {
   return true;
@@ -7,5 +7,5 @@ export async function verify(): Promise<any> {
 
 export async function action(message): Promise<void> {
   const query = 'DELETE FROM follows WHERE follower = ? AND space = ? AND network = ? LIMIT 1';
-  await db.queryAsync(query, [message.from, message.space, message.network || defaultNetwork]);
+  await db.queryAsync(query, [message.from, message.space, message.network || DEFAULT_NETWORK_ID]);
 }

--- a/test/integration/helpers/actions.test.ts
+++ b/test/integration/helpers/actions.test.ts
@@ -1,6 +1,6 @@
 import { getSpace, sxSpaceExists } from '../../../src/helpers/actions';
 import db, { sequencerDB } from '../../../src/helpers/mysql';
-import { defaultNetwork } from '../../../src/writer/follow';
+import { DEFAULT_NETWORK_ID } from '../../../src/helpers/utils';
 import { spacesSqlFixtures } from '../../fixtures/space';
 
 describe('helpers/actions', () => {
@@ -62,7 +62,9 @@ describe('helpers/actions', () => {
       });
 
       it('returns the space for the given ID with a valid network', () => {
-        return expect(getSpace('test.eth', false, defaultNetwork)).resolves.toEqual(expectedSpace);
+        return expect(getSpace('test.eth', false, DEFAULT_NETWORK_ID)).resolves.toEqual(
+          expectedSpace
+        );
       });
 
       it('returns a snapshot space for the given ID with an invalid network', () => {

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -149,8 +149,8 @@ CREATE TABLE users (
 CREATE TABLE statements (
   id VARCHAR(66) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
-  delegate VARCHAR(64) NOT NULL,
-  space VARCHAR(64) NOT NULL,
+  delegate VARCHAR(100) NOT NULL,
+  space VARCHAR(100) NOT NULL,
   about TEXT,
   statement TEXT,
   network VARCHAR(24) NOT NULL DEFAULT 's',

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -153,12 +153,18 @@ CREATE TABLE statements (
   space VARCHAR(64) NOT NULL,
   about TEXT,
   statement TEXT,
+  network VARCHAR(24) NOT NULL DEFAULT 's',
+  discourse VARCHAR(64),
+  status VARCHAR(24) NOT NULL DEFAULT 'inactive',
   created INT(11) NOT NULL,
   updated INT(11) NOT NULL,
-  PRIMARY KEY (delegate, space),
+  PRIMARY KEY (delegate, space, network),
   INDEX ipfs (ipfs),
+  INDEX space (space),
+  INDEX network (network),
   INDEX created (created),
-  INDEX updated (updated)
+  INDEX updated (updated),
+  INDEX status (status)
 );
 
 CREATE TABLE messages (


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/sx-monorepo/pull/407

This PR:

- add support for the new Statement `discourse`, `network` and `status` properties.
- update database schema, for the new columns and index (have to update schema manually before merge)

### TODO 

- [x] Update SDK to https://github.com/snapshot-labs/snapshot.js/pull/1023 before merging