### PR TITLE
fix: validate space ID (bis)

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -82,7 +82,7 @@ export default async function ingestor(req) {
 
     try {
       if (
-        (message.space.startWith('s:') || !message.space.includes(':')) &&
+        (message.space.startsWith('s:') || !message.space.includes(':')) &&
         ensNormalize(message.space) !== message.space.toLowerCase()
       )
         throw new Error('');

--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -82,6 +82,7 @@ export default async function ingestor(req) {
 
     try {
       if (
+        message.space &&
         (message.space.startsWith('s:') || !message.space.includes(':')) &&
         ensNormalize(message.space) !== message.space.toLowerCase()
       )

--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -81,7 +81,11 @@ export default async function ingestor(req) {
     type = hashTypes[hash];
 
     try {
-      if (ensNormalize(message.space) !== message.space.toLowerCase()) throw new Error('');
+      if (
+        (message.space.startWith('s:') || !message.space.includes(':')) &&
+        ensNormalize(message.space) !== message.space.toLowerCase()
+      )
+        throw new Error('');
     } catch (e) {
       return Promise.reject('Invalid space id');
     }

--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -1,3 +1,4 @@
+import { ensNormalize } from '@ethersproject/hash';
 import { pin } from '@snapshot-labs/pineapple';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
@@ -78,6 +79,12 @@ export default async function ingestor(req) {
     const hash = sha256(JSON.stringify(types));
     if (!Object.keys(hashTypes).includes(hash)) return Promise.reject('wrong types');
     type = hashTypes[hash];
+
+    try {
+      if (ensNormalize(message.space) !== message.space.toLowerCase()) throw new Error('');
+    } catch (e) {
+      return Promise.reject('Invalid space id');
+    }
 
     let aliased = false;
     if (!['settings', 'alias', 'profile'].includes(type)) {

--- a/test/integration/ingestor.test.ts
+++ b/test/integration/ingestor.test.ts
@@ -206,6 +206,13 @@ describe('ingestor', () => {
     await expect(ingestor(proposalRequest)).rejects.toEqual('duplicate message');
   });
 
+  it('rejects when the ENS name is not valid', () => {
+    const invalidRequest = cloneDeep(voteRequest);
+    // Special hidden char after the k
+    invalidRequest.body.data.message.space = 'elonmusk‍‍.eth';
+    expect(ingestor(invalidRequest)).rejects.toContain('Invalid space id');
+  });
+
   describe('on a valid transaction', () => {
     beforeEach(async () => {
       await db.queryAsync('DELETE from snapshot_sequencer_test.proposals');


### PR DESCRIPTION
Reopening same PR as #417 

But with an additional fix to validate space ID only for offchain spaces

### Test

- See #417 
- With this PR fix, we check space ID only if it's an ID sent by v1 (without network prefix), or if it's an offchain ID sent by v2 (with `s:` prefix)