### PR TITLE
fix: fix stamp cache refresh on profile name update not triggering

### DIFF
--- a/src/writer/profile.ts
+++ b/src/writer/profile.ts
@@ -40,7 +40,7 @@ export async function action(message, ipfs): Promise<void> {
 
   await db.queryAsync('REPLACE INTO users SET ?', params);
 
-  ['avatar', 'address'].forEach(async type => {
+  ['avatar', 'name'].forEach(async type => {
     if (profile[type] !== existingProfile[type]) await clearStampCache(type, message.from);
   });
 }

--- a/test/unit/writer/profile.test.ts
+++ b/test/unit/writer/profile.test.ts
@@ -39,7 +39,7 @@ describe('writer/profile', () => {
         '1'
       );
 
-      return expect(spy).toHaveBeenCalledTimes(1);
+      return expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('does not clear the stamp cache if the avatar has not changed', () => {


### PR DESCRIPTION
This PR fix the issue where the stamp cache refresh was not triggered on profile name update, due to monitoring on wrong field name 