### PR TITLE
chore: fix tests

### DIFF
--- a/test/integration/writer/profile.test.ts
+++ b/test/integration/writer/profile.test.ts
@@ -1,4 +1,4 @@
-import db from '../../../src/helpers/mysql';
+import db, { sequencerDB } from '../../../src/helpers/mysql';
 import * as utils from '../../../src/helpers/utils';
 import { action } from '../../../src/writer/profile';
 
@@ -7,6 +7,12 @@ afterEach(() => {
 });
 
 describe('writer/profile', () => {
+  afterAll(async () => {
+    await db.queryAsync('DELETE FROM users');
+    await db.endAsync();
+    await sequencerDB.endAsync();
+  });
+
   describe('action()', () => {
     const userProfile = {
       name: 'Test name',

--- a/test/integration/writer/profile.test.ts
+++ b/test/integration/writer/profile.test.ts
@@ -1,0 +1,76 @@
+import db from '../../../src/helpers/mysql';
+import * as utils from '../../../src/helpers/utils';
+import { action } from '../../../src/writer/profile';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('writer/profile', () => {
+  describe('action()', () => {
+    const userProfile = {
+      name: 'Test name',
+      avatar: 'https://snapshot.org',
+      about: 'Bio',
+      twitter: '',
+      github: ''
+    };
+
+    beforeEach(async () => {
+      await db.queryAsync('INSERT INTO users SET ?', [
+        { id: '0x0', ipfs: '0', created: 0, profile: JSON.stringify(userProfile) }
+      ]);
+    });
+
+    afterEach(async () => {
+      await db.queryAsync('DELETE FROM users WHERE id = ?', ['0x0']);
+    });
+
+    it('clears the stamp cache if the avatar has changed', async () => {
+      const spy = jest.spyOn(utils, 'clearStampCache');
+
+      await action(
+        {
+          profile: JSON.stringify({ avatar: 'https://newurl.com', name: userProfile.name }),
+          timestamp: 0,
+          from: '0x0'
+        },
+
+        '1'
+      );
+
+      return expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the stamp cache if the name has changed', async () => {
+      const spy = jest.spyOn(utils, 'clearStampCache');
+
+      await action(
+        {
+          profile: JSON.stringify({ avatar: userProfile.avatar, name: 'New name' }),
+          timestamp: 0,
+          from: '0x0'
+        },
+
+        '1'
+      );
+
+      return expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not clear the stamp cache if the avatar nor the name has changed', () => {
+      const spy = jest.spyOn(utils, 'clearStampCache');
+
+      action(
+        {
+          profile: JSON.stringify({ avatar: userProfile.avatar, name: userProfile.name }),
+          timestamp: 0,
+          from: '0x0'
+        },
+        '2'
+      );
+
+      return expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/writer/profile.test.ts
+++ b/test/unit/writer/profile.test.ts
@@ -1,56 +1,5 @@
-import db from '../../../src/helpers/mysql';
-import { action } from '../../../src/writer/profile';
-import * as utils from '../../../src/helpers/utils';
-
-afterEach(() => {
-  jest.restoreAllMocks();
-});
-
 describe('writer/profile', () => {
   describe('verify()', () => {
     it.todo('rejects if the schema is invalid');
-  });
-
-  describe('action()', () => {
-    const userProfile = {
-      name: 'Test name',
-      avatar: 'https://snapshot.org',
-      about: 'Bio',
-      twitter: '',
-      github: ''
-    };
-
-    beforeAll(async () => {
-      await db.queryAsync('INSERT INTO users SET ?', [
-        { id: '0x0', ipfs: '0', created: 0, profile: JSON.stringify(userProfile) }
-      ]);
-    });
-
-    afterAll(async () => {
-      await db.queryAsync('DELETE FROM users WHERE id = ?', ['0x0']);
-    });
-
-    it('clears the stamp cache if the avatar has changed', async () => {
-      const spy = jest.spyOn(utils, 'clearStampCache');
-
-      await action(
-        { profile: JSON.stringify({ avatar: 'https://newurl.com' }), timestamp: 0, from: '0x0' },
-
-        '1'
-      );
-
-      return expect(spy).toHaveBeenCalledTimes(2);
-    });
-
-    it('does not clear the stamp cache if the avatar has not changed', () => {
-      const spy = jest.spyOn(utils, 'clearStampCache');
-
-      action(
-        { profile: JSON.stringify({ avatar: userProfile.avatar }), timestamp: 0, from: '0x0' },
-        '2'
-      );
-
-      return expect(spy).not.toHaveBeenCalled();
-    });
   });
 });


### PR DESCRIPTION
Fix tests from #437 

Tests have been fixed incorrectly in #437, this PR fix that. There should be only 1 call to `clearStampCache`

Also move the test to integration, since they depends on a database, and are not unit test