### PR TITLE
feat: Labels on proposal

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -143,6 +143,7 @@ export default async function ingestor(req) {
         body: message.body,
         discussion: message.discussion || '',
         choices: message.choices,
+        labels: message.labels || [],
         start: message.start,
         end: message.end,
         snapshot: message.snapshot,
@@ -169,6 +170,7 @@ export default async function ingestor(req) {
         body: message.body,
         discussion: message.discussion || '',
         choices: message.choices,
+        labels: message.labels || [],
         metadata: {
           plugins: JSON.parse(message.plugins)
         },

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -233,6 +233,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     body: msg.payload.body,
     discussion: msg.payload.discussion || '',
     choices: JSON.stringify(msg.payload.choices),
+    labels: msg.payload.labels.length ? JSON.stringify(msg.payload.labels) : null,
     start: parseInt(msg.payload.start || '0'),
     end: parseInt(msg.payload.end || '0'),
     quorum,

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -233,7 +233,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     body: msg.payload.body,
     discussion: msg.payload.discussion || '',
     choices: JSON.stringify(msg.payload.choices),
-    labels: msg.payload.labels.length ? JSON.stringify(msg.payload.labels) : null,
+    labels: msg.payload.labels?.length ? JSON.stringify(msg.payload.labels) : null,
     start: parseInt(msg.payload.start || '0'),
     end: parseInt(msg.payload.end || '0'),
     quorum,

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -73,7 +73,7 @@ export async function action(body, ipfs): Promise<void> {
     body: msg.payload.body,
     discussion: msg.payload.discussion,
     choices: JSON.stringify(msg.payload.choices),
-    labels: msg.payload.labels.length ? JSON.stringify(msg.payload.labels) : null,
+    labels: msg.payload.labels?.length ? JSON.stringify(msg.payload.labels) : null,
     scores: JSON.stringify([]),
     scores_by_strategy: JSON.stringify([]),
     flagged: +containsFlaggedLinks(msg.payload.body)

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -73,6 +73,7 @@ export async function action(body, ipfs): Promise<void> {
     body: msg.payload.body,
     discussion: msg.payload.discussion,
     choices: JSON.stringify(msg.payload.choices),
+    labels: msg.payload.labels.length ? JSON.stringify(msg.payload.labels) : null,
     scores: JSON.stringify([]),
     scores_by_strategy: JSON.stringify([]),
     flagged: +containsFlaggedLinks(msg.payload.body)

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE proposals (
   body MEDIUMTEXT NOT NULL,
   discussion TEXT NOT NULL,
   choices JSON NOT NULL,
+  labels JSON DEFAULT NULL,
   start INT(11) NOT NULL,
   end INT(11) NOT NULL,
   quorum DECIMAL(64,30) NOT NULL,


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/143

### Summary
- Accepts labels on proposals

### How to test
- Run the SQL query to create new row (labels)
- Use https://github.com/snapshot-labs/sx-monorepo/pull/838 and use local sequencer and hub
- Create a proposal with labels


## TODO:
- [x] Once approved, run following on testnet and prod DB
  ```SQL
  ALTER TABLE proposals
  ADD COLUMN labels JSON DEFAULT NULL AFTER choices;
  ```