### PR TITLE
fix: Remove https from domain and default delegationNetwork to mainnet

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -10,7 +10,7 @@ export async function addOrUpdateSpace(space: string, settings: any) {
   if (settings.delegationPortal) {
     settings.delegationPortal = {
       ...settings.delegationPortal,
-      delegationNetwork: settings.delegationPortal?.delegationNetwork ?? '1'
+      delegationNetwork: settings.delegationPortal.delegationNetwork ?? '1'
     };
   }
 

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -4,6 +4,15 @@ import { DEFAULT_NETWORK_ID, jsonParse, NETWORK_ID_WHITELIST } from './utils';
 
 export async function addOrUpdateSpace(space: string, settings: any) {
   if (!settings?.name) return false;
+  if (settings.domain) {
+    settings.domain = settings.domain?.replace(/(^\w+:|^)\/\//, '').replace(/\/$/, '');
+  }
+  if (settings.delegationPortal) {
+    settings.delegationPortal = {
+      ...settings.delegationPortal,
+      delegationNetwork: settings.delegationPortal?.delegationNetwork ?? '1'
+    };
+  }
 
   const ts = (Date.now() / 1e3).toFixed();
   const query =

--- a/src/helpers/poke.ts
+++ b/src/helpers/poke.ts
@@ -11,9 +11,9 @@ export default async function poke(id: string): Promise<Space> {
   const space = await getSpaceENS(id);
 
   try {
-    // if (snapshot.utils.validateSchema(snapshot.schemas.space, space) !== true) {
-    //   return Promise.reject('invalid space format');
-    // }
+    if (snapshot.utils.validateSchema(snapshot.schemas.space, space) !== true) {
+      return Promise.reject('invalid space format');
+    }
 
     await addOrUpdateSpace(id, space);
 

--- a/src/helpers/poke.ts
+++ b/src/helpers/poke.ts
@@ -11,9 +11,9 @@ export default async function poke(id: string): Promise<Space> {
   const space = await getSpaceENS(id);
 
   try {
-    if (snapshot.utils.validateSchema(snapshot.schemas.space, space) !== true) {
-      return Promise.reject('invalid space format');
-    }
+    // if (snapshot.utils.validateSchema(snapshot.schemas.space, space) !== true) {
+    //   return Promise.reject('invalid space format');
+    // }
 
     await addOrUpdateSpace(id, space);
 


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/253

## How to test

- In `src/helpers/poke.ts` comment the code that checks validation: (until we merge https://github.com/snapshot-labs/snapshot.js/pull/1074)
```ts
// if (snapshot.utils.validateSchema(snapshot.schemas.space, space) !== true) {
    //   return Promise.reject('invalid space format');
    // }
```
- Open http://localhost:3001/spaces/cow.eth/poke
- Should save space settings without any error (domain should be saved as `vote.cow.fi`)
- In `src/helpers/actions.ts` add `delete settings.domain` on line `10`
- Open http://localhost:3001/spaces/cowtesting.eth/poke 
- Should save space settings without any error