### PR TITLE
fix: Allow signatures from sepolia safes on testnet

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -21,7 +21,7 @@ const NETWORK_METADATA = {
     name: 'snapshot',
     version: '0.1.4',
     broviderUrl: process.env.BROVIDER_URL ?? 'https://rpc.snapshot.org',
-    defaultNetwork: process.env.NETWORK === 'testnet' ? '11155111' : '1'
+    defaultNetwork: process.env.DEFAULT_NETWORK ?? '1'
   },
   starknet: {
     name: 'sx-starknet',

--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -21,7 +21,7 @@ const NETWORK_METADATA = {
     name: 'snapshot',
     version: '0.1.4',
     broviderUrl: process.env.BROVIDER_URL ?? 'https://rpc.snapshot.org',
-    defaultNetwork: '1'
+    defaultNetwork: process.env.NETWORK === 'testnet' ? '11155111' : '1'
   },
   starknet: {
     name: 'sx-starknet',


### PR DESCRIPTION
On testnet.snapshot.org we are not allowing signs from sepolia safe to update space settings, we only allow eth mainnet right now

### Summary:

- Allows signatures from sepolia safes on testnet.snapshot.org and mainnet on snapshot.org


### How to test:
- Go to your space settings on testnet 
- Update settings with a Sepolia safe
- Before fix, it should not allow
- After fix, It should allow
- It should still allow signs from mainnet on prod