### PR TITLE
feat: privacy field in proposal data

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -143,6 +143,7 @@ export default async function ingestor(req) {
         body: message.body,
         discussion: message.discussion || '',
         choices: message.choices,
+        privacy: message.privacy || '',
         labels: message.labels || [],
         start: message.start,
         end: message.end,
@@ -169,6 +170,7 @@ export default async function ingestor(req) {
         name: message.title,
         body: message.body,
         discussion: message.discussion || '',
+        privacy: message.privacy || '',
         choices: message.choices,
         labels: message.labels || [],
         metadata: {

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -103,7 +103,7 @@ export async function verify(body): Promise<any> {
     if (msg.payload.type !== space.voting.type) return Promise.reject('invalid voting type');
   }
 
-  if (space.voting?.privacy !== 'author-selection') {
+  if (space.voting?.privacy !== 'any') {
     if (msg.payload.privacy) return Promise.reject('not allowed to set privacy');
   }
 
@@ -212,7 +212,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
   const spaceNetwork = spaceSettings.network;
   const proposalSnapshot = parseInt(msg.payload.snapshot || '0');
   let privacy = spaceSettings.voting?.privacy || '';
-  if (privacy === 'author-selection') {
+  if (privacy === 'any') {
     privacy = msg.payload.privacy || '';
   }
 

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -103,8 +103,8 @@ export async function verify(body): Promise<any> {
     if (msg.payload.type !== space.voting.type) return Promise.reject('invalid voting type');
   }
 
-  if (space.voting?.privacy !== 'any') {
-    if (msg.payload.privacy) return Promise.reject('not allowed to set privacy');
+  if (space.voting?.privacy !== 'any' && msg.payload.privacy) {
+    return Promise.reject('not allowed to set privacy');
   }
 
   try {

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -213,7 +213,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
   const proposalSnapshot = parseInt(msg.payload.snapshot || '0');
   let privacy = spaceSettings.voting?.privacy || '';
   if (privacy === 'any') {
-    privacy = msg.payload.privacy || '';
+    privacy = msg.payload.privacy;
   }
 
   let quorum = spaceSettings.voting?.quorum || 0;

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -103,6 +103,10 @@ export async function verify(body): Promise<any> {
     if (msg.payload.type !== space.voting.type) return Promise.reject('invalid voting type');
   }
 
+  if (space.voting?.privacy !== 'author-selection') {
+    if (msg.payload.privacy) return Promise.reject('not allowed to set privacy');
+  }
+
   try {
     if (await isMalicious(msg.payload, space.id)) {
       return Promise.reject('invalid proposal content');
@@ -207,6 +211,10 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
   const plugins = JSON.stringify(metadata.plugins || {});
   const spaceNetwork = spaceSettings.network;
   const proposalSnapshot = parseInt(msg.payload.snapshot || '0');
+  let privacy = spaceSettings.voting?.privacy || '';
+  if (privacy === 'author-selection') {
+    privacy = msg.payload.privacy || '';
+  }
 
   let quorum = spaceSettings.voting?.quorum || 0;
   if (!quorum && spaceSettings.plugins?.quorum) {
@@ -238,7 +246,7 @@ export async function action(body, ipfs, receipt, id): Promise<void> {
     end: parseInt(msg.payload.end || '0'),
     quorum,
     quorum_type: (quorum && spaceSettings.voting?.quorumType) || '',
-    privacy: spaceSettings.voting?.privacy || '',
+    privacy,
     snapshot: proposalSnapshot || 0,
     app: kebabCase(msg.payload.app || ''),
     scores: JSON.stringify([]),

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -49,8 +49,8 @@ export async function verify(body): Promise<any> {
 
   if (proposal.author !== body.address) return Promise.reject('Not the author');
 
-  if (space.voting?.privacy !== 'any') {
-    if (msg.payload.privacy) return Promise.reject('not allowed to set privacy');
+  if (space.voting?.privacy !== 'any' && msg.payload.privacy) {
+    return Promise.reject('not allowed to set privacy');
   }
 
   const spaceUpdateError = getSpaceUpdateError({

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -70,7 +70,7 @@ export async function action(body, ipfs): Promise<void> {
   const spaceSettings = await getSpace(msg.space);
   let privacy = spaceSettings.voting?.privacy || '';
   if (privacy === 'any') {
-    privacy = msg.payload.privacy || '';
+    privacy = msg.payload.privacy;
   }
 
   const proposal = {

--- a/src/writer/update-proposal.ts
+++ b/src/writer/update-proposal.ts
@@ -49,7 +49,7 @@ export async function verify(body): Promise<any> {
 
   if (proposal.author !== body.address) return Promise.reject('Not the author');
 
-  if (space.voting?.privacy !== 'author-selection') {
+  if (space.voting?.privacy !== 'any') {
     if (msg.payload.privacy) return Promise.reject('not allowed to set privacy');
   }
 
@@ -69,7 +69,7 @@ export async function action(body, ipfs): Promise<void> {
   const plugins = JSON.stringify(metadata.plugins || {});
   const spaceSettings = await getSpace(msg.space);
   let privacy = spaceSettings.voting?.privacy || '';
-  if (privacy === 'author-selection') {
+  if (privacy === 'any') {
     privacy = msg.payload.privacy || '';
   }
 


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/277

## Summary
- Accept privacy field if space's privacy is `any`
- Else use space's privacy as default value
- Reject if proposal has `privacy` and space is not using 'any'

## How to test: 
- ~~Once a new version is created with https://github.com/snapshot-labs/snapshot.js/pull/1082~~
- Change your space settings to `any` (using UI here https://github.com/snapshot-labs/sx-monorepo/pull/954)
- Send a proposal with both `""` and `"shutter"` values in privacy