### PR TITLE
fix: Increase timestamp check to 5 days

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -55,7 +55,7 @@ export default async function ingestor(req) {
     const formattedSignature = castArray(body.sig).join(',');
     const ts = Date.now() / 1e3;
     const over = 300;
-    const under = 60 * 60 * 24 * 3; // 3 days
+    const under = 60 * 60 * 24 * 5; // 5 days
     const overTs = (ts + over).toFixed();
     const underTs = (ts - under).toFixed();
     const { domain, message, types } = body.data;


### PR DESCRIPTION
- Allows messages that are signed before 5 days time period (before it was 3 days)