### PR TITLE
fix: ignore deleted spaces when checking for followed spaces limit

### DIFF
--- a/src/writer/follow.ts
+++ b/src/writer/follow.ts
@@ -3,7 +3,12 @@ import db from '../helpers/mysql';
 import { DEFAULT_NETWORK_ID, NETWORK_IDS } from '../helpers/utils';
 
 export const getFollowsCount = async (follower: string): Promise<number> => {
-  const query = `SELECT COUNT(*) AS count FROM follows WHERE follower = ?`;
+  const query = `
+    SELECT COUNT(*) AS count
+    FROM follows
+    JOIN spaces ON spaces.id = follows.space
+    WHERE follower = ? AND spaces.deleted = 0
+  `;
 
   const [{ count }] = await db.queryAsync(query, [follower]);
 


### PR DESCRIPTION
Following on https://github.com/snapshot-labs/snapshot-sequencer/pull/401#issuecomment-2210284601

This PR fix an edge case when checking the limit of followed spaces, when a followed space has been deleted, but will still be counted toward the limit.

This PR will ignore deleted spaces from the limit count