### PR TITLE
feat: enable domain edition only on turbo and legacy spaces

### DIFF
--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -82,6 +82,10 @@ export async function verify(body): Promise<any> {
   const isAdmin = admins.includes(body.address.toLowerCase());
   const newAdmins = (msg.payload.admins || []).map(admin => admin.toLowerCase());
 
+  if (msg.payload.domain && (!space || (!space.turbo && !space.domain))) {
+    return Promise.reject('domain is a turbo feature only');
+  }
+
   const anotherSpaceWithDomain = (
     await db.queryAsync('SELECT 1 FROM spaces WHERE domain = ? AND id != ? LIMIT 1', [
       msg.payload.domain,

--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -82,7 +82,7 @@ export async function verify(body): Promise<any> {
   const isAdmin = admins.includes(body.address.toLowerCase());
   const newAdmins = (msg.payload.admins || []).map(admin => admin.toLowerCase());
 
-  if (msg.payload.domain && (!space || (!space.turbo && !space.domain))) {
+  if (msg.payload.domain && !space?.turbo && !space?.domain) {
     return Promise.reject('domain is a turbo feature only');
   }
 

--- a/test/unit/writer/settings.test.ts
+++ b/test/unit/writer/settings.test.ts
@@ -1,7 +1,7 @@
+import SpaceSchema from '@snapshot-labs/snapshot.js/src/schemas/space.json';
 import { verify } from '../../../src/writer/settings';
 import { spacesGetSpaceFixtures } from '../../fixtures/space';
 import input from '../../fixtures/writer-payload/space.json';
-import SpaceSchema from '@snapshot-labs/snapshot.js/src/schemas/space.json';
 
 function editedInput(payload = {}) {
   const result = { ...input, msg: JSON.parse(input.msg) };
@@ -104,6 +104,70 @@ describe('writer/settings', () => {
             })
           )
         ).rejects.toContain('wrong space format');
+      });
+
+      describe('when the space has an existing custom domain', () => {
+        it('accepts a new domain for non-turbo spaces', () => {
+          mockGetSpace.mockResolvedValueOnce({
+            ...spacesGetSpaceFixtures,
+            turbo: false,
+            domain: 'test.com'
+          });
+          return expect(
+            verify(
+              editedInput({
+                domain: 'test2.com'
+              })
+            )
+          ).resolves.toBeUndefined();
+        });
+
+        it('accepts a new domain for turbo spaces', () => {
+          mockGetSpace.mockResolvedValueOnce({
+            ...spacesGetSpaceFixtures,
+            turbo: true,
+            domain: 'test.com'
+          });
+          return expect(
+            verify(
+              editedInput({
+                domain: 'test2.com'
+              })
+            )
+          ).resolves.toBeUndefined();
+        });
+      });
+
+      describe('when the space does not have an existing custom domain', () => {
+        it('rejects a new domain for non-turbo spaces', () => {
+          mockGetSpace.mockResolvedValueOnce({
+            ...spacesGetSpaceFixtures,
+            turbo: false,
+            domain: undefined
+          });
+          return expect(
+            verify(
+              editedInput({
+                domain: 'test2.com'
+              })
+            )
+          ).rejects.toContain('domain is a turbo feature only');
+        });
+
+        it('accepts a new domain for turbo spaces', () => {
+          mockGetSpace.mockResolvedValueOnce({
+            ...spacesGetSpaceFixtures,
+            turbo: true,
+            domain: undefined
+          });
+          return expect(
+            verify(
+              editedInput({
+                domain: 'test2.com'
+              })
+            )
+          ).resolves.toBeUndefined();
+        });
       });
     });
 


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/362

See sister PR for sx UI https://github.com/snapshot-labs/sx-monorepo/pull/1087
Custom domain and skins will also be disabled from v1 UI with https://github.com/snapshot-labs/snapshot-v1/pull/4960

This PR will accepts a space settings update with custom domain only if:

- it's a turbo space
- the space has previously setup a custom domain