### PR TITLE
fix:  `delete-space` action should use default network instead of space network

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -91,7 +91,7 @@ export default async function ingestor(req) {
     }
 
     let aliased = false;
-    if (!['settings', 'alias', 'profile'].includes(type)) {
+    if (!['settings', 'alias', 'profile', 'delete-space'].includes(type)) {
       if (!message.space) return Promise.reject('unknown space');
 
       try {


### PR DESCRIPTION
https://github.com/snapshot-labs/sx-monorepo/pull/1218#discussion_r1971371127

This is to allow only mainnet Safes to delete spaces, similar to `settings` action