### PR TITLE
fix: accept empty string/object in plugins

### DIFF
--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -148,7 +148,7 @@ export default async function ingestor(req) {
         end: message.end,
         snapshot: message.snapshot,
         metadata: {
-          plugins: JSON.parse(message.plugins)
+          plugins: jsonParse(message.plugins, {})
         },
         type: message.type,
         app: message.app || ''
@@ -173,7 +173,7 @@ export default async function ingestor(req) {
         choices: message.choices,
         labels: message.labels || [],
         metadata: {
-          plugins: JSON.parse(message.plugins)
+          plugins: jsonParse(message.plugins, {})
         },
         type: message.type
       };


### PR DESCRIPTION
Whilte creating proposals, Our docs suggest that we need to pass `plugins`  as object in string
```js
plugins:  JSON.stringify({})
```

but many times users send a empty string or empty object for `plugins`
```js
plugins:  ''
```

```js
plugins:  {}
```

This fix will accept both and fallback to `{}`
