### PR TITLE
fix: duplicate request preventor for EIP-1271 requests

### DIFF
--- a/src/helpers/duplicateRequestPreventor.ts
+++ b/src/helpers/duplicateRequestPreventor.ts
@@ -1,9 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
-import { sendError } from './utils';
+import { sendError, sha256 } from './utils';
 
 export const ERROR_MESSAGE = 'request already being processed';
 export const queue: Set<string> = new Set();
-const hashedBody = (req: Request): string => JSON.stringify(req.body?.sig || {});
+const hashedBody = (req: Request): string => sha256(JSON.stringify(req.body || {}));
 
 export default async function duplicateRequestPreventor(
   req: Request,


### PR DESCRIPTION
Before we were using `sig` to check whether it was a duplicate or not,
But for EIP-1271 requests, `sig` is always `0x`, if two people vote at the same time on different proposals, we are processing only one

Now it is changed  to use the entire `body`

Closes https://github.com/snapshot-labs/workflow/issues/493


### How to test:
- Send two requests at same time with `sig: '0x'` and different payloads
- you can use  this diff to trick
```
diff --git a/src/api.ts b/src/api.ts
index 724a03e..28295a0 100644
--- a/src/api.ts
+++ b/src/api.ts
@@ -22,8 +22,9 @@ router.post(
   async (req: Request, res: Response, next: NextFunction) => {
     if (process.env.MAINTENANCE) return sendError(res, maintenanceMsg, 503);
     try {
-      const result = await typedData(req);
-      res.json(result);
+      // const result = await typedData(req);
+      // res.json(result);
+      res.json({ success: true });
     } catch (e: any) {
       const errorMessage = typeof e === 'object' ? e.message || JSON.stringify(e) : String(e);
       log.warn(`[ingestor] msg validation failed (typed data): ${errorMessage}`);

``` 
