### PR TITLE
fix: allow copeland on production

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -10,8 +10,6 @@ import db from '../helpers/mysql';
 import { getLimits, getSpaceType } from '../helpers/options';
 import { captureError, getQuorum, jsonParse, validateChoices } from '../helpers/utils';
 
-const SNAPSHOT_ENV = process.env.NETWORK || 'testnet';
-
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -11,7 +11,6 @@ import { getLimits, getSpaceType } from '../helpers/options';
 import { captureError, getQuorum, jsonParse, validateChoices } from '../helpers/utils';
 
 const SNAPSHOT_ENV = process.env.NETWORK || 'testnet';
-const TESTNET_ONLY_VOTING_TYPES = ['copeland'];
 
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
@@ -91,10 +90,6 @@ export async function verify(body): Promise<any> {
   const tsInt = (Date.now() / 1e3).toFixed();
   if (msg.payload.end <= tsInt) {
     return Promise.reject('proposal end date must be in the future');
-  }
-
-  if (SNAPSHOT_ENV !== 'testnet' && TESTNET_ONLY_VOTING_TYPES.includes(msg.payload.type)) {
-    return Promise.reject('voting type allowed only on testnet');
   }
 
   const isChoicesValid = validateChoices({


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/487

### Summary
- Allow copeland on production


### How to test
- Just trust me bro
- or Send a payload with copeland method on prod