### PR TITLE
fix: prevent non-premium networks

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -149,3 +149,8 @@ export async function sxSpaceExists(network: string, spaceId: string): Promise<b
   });
   return !!space?.id;
 }
+
+export async function getPremiumNetworkIds(): Promise<string[]> {
+  const premiumNetworks = await db.queryAsync('SELECT id FROM networks where premium = 1');
+  return premiumNetworks.map(network => network.id);
+}

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -47,7 +47,8 @@ async function checkNonPremiumNetworksOnSpace(space: any) {
         ? strategy.params.strategies.map((param: any) => param.network)
         : []
     )
-  ]);
+  ]).filter(Boolean);
+
   const nonPremiumNetworks = spaceNetworks.filter(network => !premiumNetworks.includes(network));
 
   if (nonPremiumNetworks.length > 0) {

--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -1,8 +1,9 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { uniq } from 'lodash';
 import { validateSpaceSettings } from './settings';
-import { getSpace } from '../helpers/actions';
+import { getPremiumNetworkIds, getSpace } from '../helpers/actions';
 import log from '../helpers/log';
 import { containsFlaggedLinks, flaggedAddresses } from '../helpers/moderation';
 import { isMalicious } from '../helpers/monitoring';
@@ -36,6 +37,24 @@ export const getProposalsCount = async (space, author) => {
   return await db.queryAsync(query, [space, author]);
 };
 
+async function checkNonPremiumNetworksOnSpace(space: any) {
+  const premiumNetworks = await getPremiumNetworkIds();
+  const spaceNetworks = uniq([
+    space.network,
+    ...space.strategies.map((strategy: any) => strategy.network),
+    ...space.strategies.flatMap((strategy: any) =>
+      Array.isArray(strategy.params?.strategies)
+        ? strategy.params.strategies.map((param: any) => param.network)
+        : []
+    )
+  ]);
+  const nonPremiumNetworks = spaceNetworks.filter(network => !premiumNetworks.includes(network));
+
+  if (nonPremiumNetworks.length > 0) {
+    return Promise.reject('space is using a non-premium network');
+  }
+}
+
 async function validateSpace(space: any) {
   if (!space) {
     return Promise.reject('unknown space');
@@ -62,6 +81,8 @@ export async function verify(body): Promise<any> {
   } catch (e) {
     return Promise.reject(`invalid space settings: ${e}`);
   }
+
+  await checkNonPremiumNetworksOnSpace(space);
 
   space.id = msg.space;
 

--- a/test/integration/ingestor.test.ts
+++ b/test/integration/ingestor.test.ts
@@ -79,7 +79,8 @@ jest.mock('../../src/helpers/actions', () => {
   return {
     __esModule: true,
     ...originalModule,
-    getSpace: (id: string) => mockGetSpace(id)
+    getSpace: (id: string) => mockGetSpace(id),
+    getPremiumNetworkIds: () => ['1', '10', '137', '250']
   };
 });
 

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -214,6 +214,15 @@ CREATE TABLE options (
   PRIMARY KEY (name)
 );
 
+CREATE TABLE networks (
+  id VARCHAR(64) NOT NULL,
+  name VARCHAR(32) NOT NULL,
+  testnet TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  premium TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  PRIMARY KEY (id),
+  INDEX premium (premium)
+);
+
 CREATE TABLE messages (
   mci INT NOT NULL AUTO_INCREMENT,
   id VARCHAR(66) NOT NULL,

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -61,7 +61,8 @@ jest.mock('../../../src/helpers/actions', () => {
   return {
     __esModule: true,
     ...originalModule,
-    getSpace: (id: string) => mockGetSpace(id)
+    getSpace: (id: string) => mockGetSpace(id),
+    getPremiumNetworkIds: () => ['1', '10', '137', '250']
   };
 });
 
@@ -188,7 +189,7 @@ describe('writer/proposal', () => {
         expect.assertions(3);
         mockGetSpace.mockResolvedValueOnce({
           ...spacesGetSpaceFixtures,
-          strategies: [{ name: 'ticket' }],
+          strategies: [{ name: 'ticket', network: '1' }],
           voteValidation: { name: 'gitcoin' }
         });
 

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -586,6 +586,28 @@ describe('writer/proposal', () => {
         expect(mockGetSpace).toHaveBeenCalledTimes(1);
       });
 
+      it('rejects if using a non-premium network', async () => {
+        expect.assertions(2);
+        mockGetSpace.mockResolvedValueOnce({
+          ...spacesGetSpaceFixtures,
+          network: '56' // Using BSC network, which is not in the premium list
+        });
+
+        await expect(writer.verify(input)).rejects.toMatch('space is using a non-premium network');
+        expect(mockGetSpace).toHaveBeenCalledTimes(1);
+      });
+
+      it('rejects if strategies use a non-premium network', async () => {
+        expect.assertions(2);
+        mockGetSpace.mockResolvedValueOnce({
+          ...spacesGetSpaceFixtures,
+          strategies: [{ name: 'erc20-balance-of', network: '56' }] // Non-premium network
+        });
+
+        await expect(writer.verify(input)).rejects.toMatch('space is using a non-premium network');
+        expect(mockGetSpace).toHaveBeenCalledTimes(1);
+      });
+
       it('rejects if missing proposal validation', async () => {
         expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -189,7 +189,7 @@ describe('writer/proposal', () => {
         expect.assertions(3);
         mockGetSpace.mockResolvedValueOnce({
           ...spacesGetSpaceFixtures,
-          strategies: [{ name: 'ticket', network: '1' }],
+          strategies: [{ name: 'ticket' }],
           voteValidation: { name: 'gitcoin' }
         });
 

--- a/test/unit/writer/settings.test.ts
+++ b/test/unit/writer/settings.test.ts
@@ -79,7 +79,8 @@ jest.mock('../../../src/helpers/actions', () => {
   return {
     __esModule: true,
     ...originalModule,
-    getSpace: (id: string) => mockGetSpace(id)
+    getSpace: (id: string) => mockGetSpace(id),
+    getPremiumNetworkIds: () => ['1', '10', '137', '250']
   };
 });
 


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/497

## Summary
Stops proposal creation for spaces using non-premium network (main network, network inside strategy or inside multichain strategy)

### How to test
- Try changing the settings of space to use a non-premium network
- Create a proposal on v1
- It should throw any error
![image](https://github.com/user-attachments/assets/c057e4ae-4fa0-4c40-9b96-7e61287d3276)

