### PR TITLE
fix: allow turbo spaces to create proposals with non-premium networks

### DIFF
--- a/src/writer/proposal.ts
+++ b/src/writer/proposal.ts
@@ -83,12 +83,12 @@ export async function verify(body): Promise<any> {
     return Promise.reject(`invalid space settings: ${e}`);
   }
 
-  await checkNonPremiumNetworksOnSpace(space);
-
   space.id = msg.space;
 
   const spaceType = await getSpaceType(space);
   const spaceTypeWithEcosystem = await getSpaceType(space, true);
+
+  if (spaceType !== 'turbo') await checkNonPremiumNetworksOnSpace(space);
 
   const limits = await getLimits([
     `space.${spaceType}.body_limit`,

--- a/test/unit/writer/proposal.test.ts
+++ b/test/unit/writer/proposal.test.ts
@@ -597,6 +597,19 @@ describe('writer/proposal', () => {
         expect(mockGetSpace).toHaveBeenCalledTimes(1);
       });
 
+      it('should not reject if using a premium network for turbo space', async () => {
+        expect.assertions(3);
+        mockGetSpace.mockResolvedValueOnce({
+          ...spacesGetSpaceFixtures,
+          network: '56', // Using Ethereum mainnet, which is in the premium list
+          turbo: '1'
+        });
+
+        await expect(writer.verify(input)).resolves.toBeUndefined();
+        expect(mockGetSpace).toHaveBeenCalledTimes(1);
+        expect(mockGetProposalsCount).toHaveBeenCalledTimes(1);
+      });
+
       it('rejects if strategies use a non-premium network', async () => {
         expect.assertions(2);
         mockGetSpace.mockResolvedValueOnce({


### PR DESCRIPTION
Right now we are not allowing turbo spaces to create proposals with non-premium networks


### How to test
- Create  proposal with turbo space