### PR TITLE
chore: use pineapple gateway to get JSON on poke

### DIFF
--- a/src/helpers/poke.ts
+++ b/src/helpers/poke.ts
@@ -33,7 +33,9 @@ async function getSpaceENS(id: string): Promise<Space> {
     }
 
     try {
-      return await snapshot.utils.getJSON(uri);
+      return await snapshot.utils.getJSON(uri, {
+        gateways: ['pineapple.fyi']
+      });
     } catch (e) {
       return Promise.reject(`${uri} is not a valid JSON file`);
     }


### PR DESCRIPTION
Use pineapple gateway on poke

### How to test:
- Attach a network listner
- try going to http://localhost:3001/spaces/testsnapshotspace.eth/poke
- you should see the request is sent to pineapple instead of ipfs.snapshot.box