### PR TITLE
feat: add delay before finalizing proposal scores

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,6 @@ import { name, version } from '../package.json';
 
 const router = express.Router();
 const SNAPSHOT_ENV = process.env.NETWORK || 'testnet';
-const SCORE_FINALIZATION_DELAY = 60000;
 
 const maintenanceMsg = 'update in progress, try later';
 
@@ -48,18 +47,15 @@ router.get('/', (req, res) => {
 });
 
 router.get('/scores/:proposalId', async (req, res) => {
-  // Delay the score finalization to allow some time for last minute votes to complete
-  setTimeout(async () => {
-    const { proposalId } = req.params;
-    try {
-      await serve(proposalId, updateProposalAndVotes, [proposalId]);
-    } catch (e) {
-      capture(e);
-      log.warn(`[api] updateProposalAndVotes() failed ${proposalId}, ${JSON.stringify(e)}`);
-    }
-  }, SCORE_FINALIZATION_DELAY);
-
-  return res.json({ result: 'pending' });
+  const { proposalId } = req.params;
+  try {
+    const result = await serve(proposalId, updateProposalAndVotes, [proposalId]);
+    return res.json({ result });
+  } catch (e) {
+    capture(e);
+    log.warn(`[api] updateProposalAndVotes() failed ${proposalId}, ${JSON.stringify(e)}`);
+    return res.json({ error: 'failed', message: e });
+  }
 });
 
 router.get('/spaces/:key/poke', async (req, res) => {

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -113,7 +113,7 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
 
   // Delay computation of final scores, to allow time for last minute votes to finish
   // up to 1 minute after the end of the proposal
-  if (proposal.end <= ts && proposal.scores_state !== 'final') {
+  if (proposal.end <= ts) {
     const secondsSinceEnd = ts - proposal.end;
     await snapshot.utils.sleep(Math.max(FINALIZE_SCORE_SECONDS_DELAY - secondsSinceEnd, 0) * 1000);
   }

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -5,6 +5,7 @@ import { getDecryptionKey } from './helpers/shutter';
 import { hasStrategyOverride, sha256 } from './helpers/utils';
 
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
+const FINALIZE_SCORE_SECONDS_DELAY = 60;
 
 async function getProposal(id: string): Promise<any | undefined> {
   const query = 'SELECT * FROM proposals WHERE id = ? LIMIT 1';
@@ -108,8 +109,21 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
     return true;
   }
 
-  // Ignore score calculation if proposal have more than 100k votes and scores_updated greater than 5 minute
   const ts = Number((Date.now() / 1e3).toFixed());
+
+  // Delay computation of final scores, to allow time for last minute votes to finish
+  // up to 1 minute after the end of the proposal
+  if (proposal.end <= ts && proposal.scores_state !== 'final') {
+    const secondsSinceEnd = ts - proposal.end;
+    await snapshot.utils.sleep(
+      Math.min(
+        Math.max(FINALIZE_SCORE_SECONDS_DELAY - secondsSinceEnd, 0),
+        FINALIZE_SCORE_SECONDS_DELAY
+      ) * 1000
+    );
+  }
+
+  // Ignore score calculation if proposal have more than 100k votes and scores_updated greater than 5 minute
   if (
     (proposal.votes > 20000 && proposal.scores_updated > ts - 300) ||
     pendingRequests[proposalId]

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -115,9 +115,7 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
   // up to 1 minute after the end of the proposal
   if (proposal.end <= ts && proposal.scores_state !== 'final') {
     const secondsSinceEnd = ts - proposal.end;
-    await snapshot.utils.sleep(
-      Math.max(FINALIZE_SCORE_SECONDS_DELAY - secondsSinceEnd, 0) * 1000
-    );
+    await snapshot.utils.sleep(Math.max(FINALIZE_SCORE_SECONDS_DELAY - secondsSinceEnd, 0) * 1000);
   }
 
   // Ignore score calculation if proposal have more than 100k votes and scores_updated greater than 5 minute

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -116,10 +116,7 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
   if (proposal.end <= ts && proposal.scores_state !== 'final') {
     const secondsSinceEnd = ts - proposal.end;
     await snapshot.utils.sleep(
-      Math.min(
-        Math.max(FINALIZE_SCORE_SECONDS_DELAY - secondsSinceEnd, 0),
-        FINALIZE_SCORE_SECONDS_DELAY
-      ) * 1000
+      Math.max(FINALIZE_SCORE_SECONDS_DELAY - secondsSinceEnd, 0) * 1000
     );
   }
 


### PR DESCRIPTION
This PR fix the issue where a last minute vote just before proposal closing is not taken into account when computing the proposal final score, due to concurrency issue