### PR TITLE
feat: allow vote and proposal handling from starknet aliases

### DIFF
--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -1,6 +1,8 @@
 import { uniq } from 'lodash';
 import db from './mysql';
 
+const DEFAULT_ALIAS_EXPIRY_DAYS = 30;
+
 // These types can always be executed with an alias
 const TYPES_EXECUTABLE_BY_ALIAS = [
   'follow',
@@ -9,7 +11,8 @@ const TYPES_EXECUTABLE_BY_ALIAS = [
   'unsubscribe',
   'profile',
   'statement'
-];
+] as const;
+
 // These types can be executed with an alias only when enabled in the space settings
 const OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS = [
   'vote',
@@ -17,24 +20,42 @@ const OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS = [
   'vote-string',
   'proposal',
   'delete-proposal'
-];
+] as const;
+
 // These types can be executed with a Starknet alias
 const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = [
   ...OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS,
   'update-proposal'
-];
+] as const;
 
-export async function isExistingAlias(address: string, alias: string): Promise<boolean> {
-  const query = `SELECT
-      address
+// Memoization cache for getAllowedTypes
+const allowedTypesCache = new Map<string, ExecutableType[]>();
+
+// Types
+type ExecutableType =
+  | (typeof TYPES_EXECUTABLE_BY_ALIAS)[number]
+  | (typeof OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS)[number]
+  | 'update-proposal';
+
+/**
+ * Checks if an alias relationship exists and is not expired
+ * @param address - The original address
+ * @param alias - The alias address to check
+ * @param expiryDays - Number of days after which alias expires (default: 30)
+ * @returns Promise<boolean> - True if valid alias exists
+ */
+export async function isExistingAlias(
+  address: string,
+  alias: string,
+  expiryDays = DEFAULT_ALIAS_EXPIRY_DAYS
+): Promise<boolean> {
+  const query = `SELECT 1
     FROM aliases
-    WHERE
-      address = ?
-      AND alias = ?
-      AND created > (UNIX_TIMESTAMP(NOW()) - 30 * 24 * 60 * 60)
+    WHERE address = ? AND alias = ?
+      AND created > DATE_SUB(NOW(), INTERVAL ? DAY)
     LIMIT 1`;
-  const results = await db.queryAsync(query, [address, alias]);
 
+  const results = await db.queryAsync(query, [address, alias, expiryDays]);
   return results.length > 0;
 }
 
@@ -43,7 +64,11 @@ export async function verifyAlias(type: string, body: any, optionalAlias = false
 
   if (body.address === message.from) return;
 
-  if (!getAllowedTypes(optionalAlias, isStarknetAddress(message.from)).includes(type)) {
+  if (
+    !getAllowedTypes(optionalAlias, isStarknetAddress(message.from)).includes(
+      type as ExecutableType
+    )
+  ) {
     return Promise.reject(`alias not allowed for the type: ${type}`);
   }
 
@@ -58,8 +83,14 @@ export function isStarknetAddress(address: string): boolean {
   return /^0x[0-9a-fA-F]{64}$/.test(address);
 }
 
-export function getAllowedTypes(withAlias: boolean, forStarknet: boolean): string[] {
-  const types = [...TYPES_EXECUTABLE_BY_ALIAS];
+export function getAllowedTypes(withAlias: boolean, forStarknet: boolean): ExecutableType[] {
+  const cacheKey = `${withAlias}-${forStarknet}`;
+
+  if (allowedTypesCache.has(cacheKey)) {
+    return allowedTypesCache.get(cacheKey)!;
+  }
+
+  const types: ExecutableType[] = [...TYPES_EXECUTABLE_BY_ALIAS];
 
   if (withAlias) {
     types.push(...OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS);
@@ -69,5 +100,7 @@ export function getAllowedTypes(withAlias: boolean, forStarknet: boolean): strin
     types.push(...TYPES_EXECUTABLE_BY_STARKNET_ALIAS);
   }
 
-  return uniq(types);
+  const result = uniq(types);
+  allowedTypesCache.set(cacheKey, result);
+  return result;
 }

--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -19,14 +19,12 @@ const OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS = [
   'vote-array',
   'vote-string',
   'proposal',
+  'update-proposal',
   'delete-proposal'
 ] as const;
 
 // These types can be executed with a Starknet alias
-const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = [
-  ...OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS,
-  'update-proposal'
-] as const;
+const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = [...OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS] as const;
 
 // Memoization cache for getAllowedTypes
 const allowedTypesCache = new Map<string, ExecutableType[]>();

--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -1,10 +1,69 @@
 import db from './mysql';
 
-export async function isValidAlias(address: string, alias: string): Promise<boolean> {
-  const thirtyDaysAgo = Math.floor(new Date().getTime() / 1000) - 30 * 24 * 60 * 60;
+// These types can always be executed with an alias
+const TYPES_EXECUTABLE_BY_ALIAS = [
+  'follow',
+  'unfollow',
+  'subscribe',
+  'unsubscribe',
+  'profile',
+  'statement'
+];
+// These types can be executed with an alias only when enabled in the space settings
+const OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS = [
+  'vote',
+  'vote-array',
+  'vote-string',
+  'proposal',
+  'delete-proposal'
+];
+// These types can be executed with a Starknet alias
+const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS;
 
-  const query =
-    'SELECT address, alias FROM aliases WHERE address = ? AND alias = ? AND created > ? LIMIT 1';
-  const results = await db.queryAsync(query, [address, alias, thirtyDaysAgo]);
-  return !!results[0];
+export async function isExistingAlias(address: string, alias: string): Promise<boolean> {
+  const query = `SELECT
+      address
+    FROM aliases
+    WHERE
+      address = ?
+      AND alias = ?
+      AND created > (UNIX_TIMESTAMP(NOW()) - 30 * 24 * 60 * 60)
+    LIMIT 1`;
+  const results = await db.queryAsync(query, [address, alias]);
+
+  return results.length > 0;
+}
+
+export async function verifyAlias(type: string, body: any, optionalAlias = false): Promise<void> {
+  const { message } = body.data;
+
+  if (body.address === message.from) return;
+
+  if (!getAllowedTypes(optionalAlias, isStarknetAddress(message.from)).includes(type)) {
+    return Promise.reject(`alias not allowed for the type: ${type}`);
+  }
+
+  if (!(await isExistingAlias(message.from, body.address))) {
+    return Promise.reject('wrong alias');
+  }
+}
+
+// Loose checking here, as we're looking for this address in the database later,
+// which will always be a formatted starknet address if valid.
+export function isStarknetAddress(address: string): boolean {
+  return /^0x[0-9a-fA-F]{64}$/.test(address);
+}
+
+export function getAllowedTypes(withAlias: boolean, forStarknet: boolean): string[] {
+  const types = TYPES_EXECUTABLE_BY_ALIAS;
+
+  if (withAlias) {
+    types.push(...OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS);
+  }
+
+  if (forStarknet) {
+    types.push(...TYPES_EXECUTABLE_BY_STARKNET_ALIAS);
+  }
+
+  return types;
 }

--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -55,7 +55,7 @@ export function isStarknetAddress(address: string): boolean {
 }
 
 export function getAllowedTypes(withAlias: boolean, forStarknet: boolean): string[] {
-  const types = TYPES_EXECUTABLE_BY_ALIAS;
+  const types = [...TYPES_EXECUTABLE_BY_ALIAS];
 
   if (withAlias) {
     types.push(...OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS);

--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -52,7 +52,7 @@ export async function isExistingAlias(
   const query = `SELECT 1
     FROM aliases
     WHERE address = ? AND alias = ?
-      AND created > DATE_SUB(NOW(), INTERVAL ? DAY)
+      AND created > UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL ? DAY))
     LIMIT 1`;
 
   const results = await db.queryAsync(query, [address, alias, expiryDays]);

--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -1,3 +1,4 @@
+import { uniq } from 'lodash';
 import db from './mysql';
 
 // These types can always be executed with an alias
@@ -68,5 +69,5 @@ export function getAllowedTypes(withAlias: boolean, forStarknet: boolean): strin
     types.push(...TYPES_EXECUTABLE_BY_STARKNET_ALIAS);
   }
 
-  return types;
+  return uniq(types);
 }

--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -18,7 +18,10 @@ const OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS = [
   'delete-proposal'
 ];
 // These types can be executed with a Starknet alias
-const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS;
+const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = [
+  ...OPTIONAL_TYPES_EXECUTABLE_BY_ALIAS,
+  'update-proposal'
+];
 
 export async function isExistingAlias(address: string, alias: string): Promise<boolean> {
   const query = `SELECT

--- a/src/helpers/shutter.ts
+++ b/src/helpers/shutter.ts
@@ -63,7 +63,6 @@ export async function getDecryptionKey(proposal: string, url: string = SHUTTER_U
   return result;
 }
 
-
 async function setEonPubkey(params) {
   log.info(`[shutter] set eon pubkey ${JSON.stringify(params)}`);
   return true;

--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -5,7 +5,7 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import hashTypes from '@snapshot-labs/snapshot.js/src/sign/hashedTypes.json';
 import castArray from 'lodash/castArray';
 import { getProposal, getSpace } from './helpers/actions';
-import { isValidAlias } from './helpers/alias';
+import { verifyAlias } from './helpers/alias';
 import envelope from './helpers/envelope.json';
 import { doesMessageExist, storeMsg } from './helpers/highlight';
 import log from './helpers/log';
@@ -104,17 +104,7 @@ export default async function ingestor(req) {
       }
     }
 
-    // Check if signing address is an alias
-    const aliasTypes = ['follow', 'unfollow', 'subscribe', 'unsubscribe', 'profile', 'statement'];
-    const aliasOptionTypes = ['vote', 'vote-array', 'vote-string', 'proposal', 'delete-proposal'];
-    if (body.address !== message.from) {
-      if (!aliasTypes.includes(type) && !aliasOptionTypes.includes(type))
-        return Promise.reject('wrong from');
-
-      if (aliasOptionTypes.includes(type) && !aliased) return Promise.reject('alias not enabled');
-
-      if (!(await isValidAlias(message.from, body.address))) return Promise.reject('wrong alias');
-    }
+    await verifyAlias(type, body, aliased);
 
     // Check if signature is valid
     try {

--- a/test/fixtures/alias.ts
+++ b/test/fixtures/alias.ts
@@ -1,0 +1,23 @@
+export const aliasesSqlFixtures: Record<string, any>[] = [
+  {
+    id: '1',
+    ipfs: 'Qm...',
+    address: '0x0000000000000000000000000000000000000000',
+    alias: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+    created: Math.floor(Date.now() / 1000)
+  },
+  {
+    id: '2',
+    ipfs: 'Qm...',
+    address: '0x02a0a8f3b6097e7a6bd7649deb30715323072a159c0e6b71b689bd245c146cc0',
+    alias: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+    created: Math.floor(Date.now() / 1000)
+  },
+  {
+    id: '3',
+    ipfs: 'Qm...',
+    address: '0x02a0a8f3b6097e7a6bd7649deb30715323072a159c0e6b71b689bd245c146cc0',
+    alias: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f4',
+    created: 1
+  }
+];

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -27,7 +27,7 @@ describe('alias', () => {
     await sequencerDB.endAsync();
   });
 
-  describe('isValidAlias()', () => {
+  describe('isExistingAlias()', () => {
     it('should return true for valid alias', () => {
       expect(
         isExistingAlias(aliasesSqlFixtures[0].address, aliasesSqlFixtures[0].alias)

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -1,0 +1,47 @@
+import { isExistingAlias } from '../../../src/helpers/alias';
+import db, { sequencerDB } from '../../../src/helpers/mysql';
+import { aliasesSqlFixtures } from '../../fixtures/alias';
+
+describe('alias', () => {
+  const seed = Date.now().toFixed(0);
+
+  beforeAll(async () => {
+    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases');
+    await Promise.all(
+      aliasesSqlFixtures.map(alias => {
+        const values = {
+          ...alias,
+          ipfs: seed
+        };
+        return db.queryAsync('INSERT INTO snapshot_sequencer_test.aliases SET ?', values);
+      })
+    );
+  });
+
+  afterEach(async () => {
+    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases where ipfs = ?', seed);
+  });
+
+  afterAll(async () => {
+    await db.endAsync();
+    await sequencerDB.endAsync();
+  });
+
+  describe('isValidAlias()', () => {
+    it('should return true for valid alias', () => {
+      expect(
+        isExistingAlias(aliasesSqlFixtures[0].address, aliasesSqlFixtures[0].alias)
+      ).resolves.toBe(true);
+    });
+
+    it('should return false for un-existing alias', () => {
+      expect(isExistingAlias(aliasesSqlFixtures[0].address, 'invalid-alias')).resolves.toBe(false);
+    });
+
+    it('should return false for expired alias', () => {
+      expect(
+        isExistingAlias(aliasesSqlFixtures[2].address, aliasesSqlFixtures[2].alias)
+      ).resolves.toBe(false);
+    });
+  });
+});

--- a/test/unit/helpers/alias.test.ts
+++ b/test/unit/helpers/alias.test.ts
@@ -27,7 +27,7 @@ describe('Alias', () => {
       const result = getAllowedTypes(true, false);
       expect(result).toContain('profile');
       expect(result).toContain('vote');
-      expect(result).not.toContain('update-proposal');
+      expect(result).toContain('update-proposal');
     });
     it('should return the correct types when withAlias is false and forStarknet is true', () => {
       const result = getAllowedTypes(false, true);

--- a/test/unit/helpers/alias.test.ts
+++ b/test/unit/helpers/alias.test.ts
@@ -1,0 +1,43 @@
+import { getAllowedTypes, isStarknetAddress } from '../../../src/helpers/alias';
+
+describe('Alias', () => {
+  describe('isStarknetAddress()', () => {
+    it('should return true for a starknet address', () => {
+      expect(
+        isStarknetAddress('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef')
+      ).toBe(true);
+    });
+    it('should return false for a non-starknet address', () => {
+      expect(isStarknetAddress('0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3')).toBe(false);
+    });
+    it('should return false for an invalid address', () => {
+      expect(isStarknetAddress('')).toBe(false);
+      expect(isStarknetAddress('test')).toBe(false);
+    });
+  });
+
+  describe('getAllowedTypes()', () => {
+    it('should return the correct types when both withAlias and forStarknet are false', () => {
+      const result = getAllowedTypes(false, false);
+      expect(result).toContain('profile');
+      expect(result).not.toContain('vote');
+    });
+    it('should return the correct types when withAlias is true and forStarknet is false', () => {
+      const result = getAllowedTypes(true, false);
+      expect(result).toContain('profile');
+      expect(result).toContain('vote');
+    });
+    it('should return the correct types when withAlias is false and forStarknet is true', () => {
+      const result = getAllowedTypes(false, true);
+      expect(result).toContain('profile');
+      expect(result).toContain('statement');
+      expect(result).toContain('vote');
+    });
+    it('should return the correct types when both withAlias and forStarknet are true', () => {
+      const result = getAllowedTypes(true, true);
+      expect(result).toContain('profile');
+      expect(result).toContain('statement');
+      expect(result).toContain('vote');
+    });
+  });
+});

--- a/test/unit/helpers/alias.test.ts
+++ b/test/unit/helpers/alias.test.ts
@@ -21,11 +21,13 @@ describe('Alias', () => {
       const result = getAllowedTypes(false, false);
       expect(result).toContain('profile');
       expect(result).not.toContain('vote');
+      expect(result).not.toContain('update-proposal');
     });
     it('should return the correct types when withAlias is true and forStarknet is false', () => {
       const result = getAllowedTypes(true, false);
       expect(result).toContain('profile');
       expect(result).toContain('vote');
+      expect(result).not.toContain('update-proposal');
     });
     it('should return the correct types when withAlias is false and forStarknet is true', () => {
       const result = getAllowedTypes(false, true);

--- a/test/unit/helpers/alias.test.ts
+++ b/test/unit/helpers/alias.test.ts
@@ -30,14 +30,14 @@ describe('Alias', () => {
     it('should return the correct types when withAlias is false and forStarknet is true', () => {
       const result = getAllowedTypes(false, true);
       expect(result).toContain('profile');
-      expect(result).toContain('statement');
       expect(result).toContain('vote');
+      expect(result).toContain('update-proposal');
     });
     it('should return the correct types when both withAlias and forStarknet are true', () => {
       const result = getAllowedTypes(true, true);
       expect(result).toContain('profile');
-      expect(result).toContain('statement');
       expect(result).toContain('vote');
+      expect(result).toContain('update-proposal');
     });
   });
 });


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/562

This PR allows aliases from starknet address to submit votes and create/delete proposals

### How to test

- Add a whitelist voting strategy to your space, with your starknet address
- Create an alias with your starknet address
- Using the SDK, submit a vote with that alias/create a proposal with that alias (set the `from` to your starknet address)

Depends on https://github.com/snapshot-labs/snapshot.js/pull/1152