### PR TITLE
feat: sign receipts via EIP712

### DIFF
--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -5,6 +5,8 @@ import Connection from 'mysql/lib/Connection';
 import Pool from 'mysql/lib/Pool';
 import log from './log';
 
+bluebird.promisifyAll([Pool, Connection]);
+
 const connectionLimit = parseInt(process.env.CONNECTION_LIMIT ?? '25');
 log.info(`[mysql] connection limit ${connectionLimit}`);
 
@@ -19,7 +21,6 @@ hubConfig.connectTimeout = 60e3;
 hubConfig.acquireTimeout = 60e3;
 hubConfig.timeout = 60e3;
 hubConfig.charset = 'utf8mb4';
-bluebird.promisifyAll([Pool, Connection]);
 const hubDB = mysql.createPool(hubConfig);
 
 // @ts-ignore
@@ -33,7 +34,6 @@ sequencerConfig.connectTimeout = 60e3;
 sequencerConfig.acquireTimeout = 60e3;
 sequencerConfig.timeout = 60e3;
 sequencerConfig.charset = 'utf8mb4';
-bluebird.promisifyAll([Pool, Connection]);
 const sequencerDB = mysql.createPool(sequencerConfig);
 
 export { hubDB as default, sequencerDB };

--- a/src/helpers/relayer.ts
+++ b/src/helpers/relayer.ts
@@ -1,11 +1,32 @@
-import { Wallet } from '@ethersproject/wallet';
+import { verifyTypedData, Wallet } from '@ethersproject/wallet';
+
+const RECEIPT_DOMAIN = {
+  name: 'snapshot-receipt',
+  version: '0.1.0'
+};
+
+const RECEIPT_TYPES = {
+  Receipt: [{ name: 'sig', type: 'string' }]
+};
 
 const privateKey = process.env.RELAYER_PK ?? '';
 const wallet = new Wallet(privateKey);
 
-// @TODO use EIP712 for relayer message
-export async function issueReceipt(id) {
-  return await wallet.signMessage(id);
+function getReceiptData(sig: string) {
+  return { sig };
+}
+
+export async function issueReceipt(sig: string) {
+  return await wallet._signTypedData(RECEIPT_DOMAIN, RECEIPT_TYPES, getReceiptData(sig));
+}
+
+export function verifyReceipt(sig: string, receipt: string): boolean {
+  try {
+    const signer = verifyTypedData(RECEIPT_DOMAIN, RECEIPT_TYPES, getReceiptData(sig), receipt);
+    return signer.toLowerCase() === wallet.address.toLowerCase();
+  } catch (e) {
+    return false;
+  }
 }
 
 export default wallet;

--- a/src/ingestor.ts
+++ b/src/ingestor.ts
@@ -11,7 +11,7 @@ import { doesMessageExist, storeMsg } from './helpers/highlight';
 import log from './helpers/log';
 import { timeIngestorProcess } from './helpers/metrics';
 import { flaggedIps } from './helpers/moderation';
-import relayer, { issueReceipt } from './helpers/relayer';
+import relayer, { issueReceipt, verifyReceipt } from './helpers/relayer';
 import { getIp, jsonParse, sha256 } from './helpers/utils';
 import writer from './writer';
 
@@ -239,6 +239,8 @@ export default async function ingestor(req) {
         pin(ipfsBody, process.env.PINEAPPLE_URL),
         issueReceipt(formattedSignature)
       ]);
+
+      if (!verifyReceipt(formattedSignature, receipt)) throw new Error('invalid relayer receipt');
     } catch (e) {
       capture(e);
       return Promise.reject('pinning failed');

--- a/test/integration/ingestor.test.ts
+++ b/test/integration/ingestor.test.ts
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 import omit from 'lodash/omit';
 import db, { sequencerDB } from '../../src/helpers/mysql';
-import relayer from '../../src/helpers/relayer';
+import relayer, { verifyReceipt } from '../../src/helpers/relayer';
 import ingestor from '../../src/ingestor';
 import proposalInput from '../fixtures/ingestor-payload/proposal.json';
 import voteInput from '../fixtures/ingestor-payload/vote.json';
@@ -278,6 +278,7 @@ describe('ingestor', () => {
       expect(result).toHaveProperty('relayer');
       expect(result.relayer.address).toEqual(relayer.address);
       expect(result.relayer).toHaveProperty('receipt');
+      expect(verifyReceipt(proposalRequest.body.sig, result.relayer.receipt)).toBe(true);
     });
 
     it('saves the proposal in the DB', async () => {


### PR DESCRIPTION
- Created a typed-data domain and signing/verification helpers so relayer receipts use EIP-712 signatures
- Updated ingestor to verify the relayer’s receipt before storing messages
- Added tests ensuring that the receipt signature can be verified against the proposal request