### PR TITLE
feat: prevent spaces from setting themselves as parent or child

### DIFF
--- a/src/writer/settings.ts
+++ b/src/writer/settings.ts
@@ -28,6 +28,18 @@ export async function validateSpaceSettings(originalSpace: any) {
   delete space.hibernated;
   delete space.id;
 
+  if (space.parent && space.parent === originalSpace.id) {
+    return Promise.reject('space cannot be its own parent');
+  }
+
+  if (
+    space.children &&
+    Array.isArray(space.children) &&
+    space.children.includes(originalSpace.id)
+  ) {
+    return Promise.reject('space cannot be its own child');
+  }
+
   const schemaIsValid: any = snapshot.utils.validateSchema(snapshot.schemas.space, space, {
     spaceType,
     snapshotEnv: SNAPSHOT_ENV
@@ -72,6 +84,7 @@ export async function verify(body): Promise<any> {
   try {
     await validateSpaceSettings({
       ...msg.payload,
+      id: msg.space,
       deleted: space?.deleted,
       turbo: space?.turbo
     });

--- a/test/unit/writer/settings.test.ts
+++ b/test/unit/writer/settings.test.ts
@@ -131,6 +131,29 @@ describe('writer/settings', () => {
           verify(editedInput({ validation: { name: 'any' }, strategies: [{ name: 'ticket' }] }))
         ).rejects.toContain('space with ticket requires voting validation');
       });
+
+      it('rejects if space tries to set itself as parent', async () => {
+        return expect(verify(editedInput({ parent: 'fabien.eth' }))).rejects.toContain(
+          'space cannot be its own parent'
+        );
+      });
+
+      it('rejects if space tries to include itself in children array', async () => {
+        return expect(
+          verify(editedInput({ children: ['other-space.eth', 'fabien.eth', 'another-space.eth'] }))
+        ).rejects.toContain('space cannot be its own child');
+      });
+
+      it('accepts valid parent that is not the space itself', async () => {
+        return expect(verify(editedInput({ parent: 'parent-space.eth' }))).resolves.toBeUndefined();
+      });
+
+      it('accepts valid children array that does not include the space itself', async () => {
+        return expect(
+          verify(editedInput({ children: ['child1.eth', 'child2.eth'] }))
+        ).resolves.toBeUndefined();
+      });
+
       it.todo('rejects if the submitter does not have permission');
       it.todo('rejects if the submitter does not have permission to change admin');
       const maxStrategiesForNormalSpace = LIMITS['space.default.strategies_limit'];


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/workflow/issues/605

## Summary

This PR adds validation to prevent spaces from creating circular references in the space hierarchy by setting themselves as their own parent or including themselves in their children array.

## Testing
- All existing tests continue to pass
- New tests validate both rejection and acceptance scenarios