### PR TITLE
feat: add support for sonic domain name

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -259,7 +259,7 @@ export function getSpaceController(space: string, network = NETWORK) {
       testnet: '157'
     },
     sonic: {
-      mainnet: '147'
+      mainnet: '146'
     }
   };
   const networkId = tldMapping[tld]?.[network] ?? DEFAULT_NETWORK;


### PR DESCRIPTION
Add support for sonic domain name

The SDK is already handling the domain name correctly, this PR updates the code to send the correct network to the `getSpaceController` function when a .sonic domain is detected