### PR TITLE
feat: add vp value to leaderboard

### DIFF
--- a/docs/cb-flow.md
+++ b/docs/cb-flow.md
@@ -8,6 +8,7 @@
 | -1 | `PENDING_COMPUTE` | Strategy values synced. Waiting for `scores_total_value` computation | Default. Waiting for `vp_value` computation |
 | -2 | `PENDING_FINAL` | Score value computed, but proposal still active | Value computed, but `vp_state` not final |
 | 1 | `FINAL` | Fully computed | Fully computed |
+| -3 | `PENDING_DELETE` | N/A | Proposal deleted, vote awaiting async cleanup |
 | -10 | `INELIGIBLE` | Invalid payload format, cannot compute (permanent) | Invalid data, cannot compute (permanent) |
 | -11 | `ERROR_SYNC` | Overlord sync failed, will be retried | N/A |
 
@@ -54,14 +55,23 @@ flowchart TD
     C -->|No| E["cb = -2<br>PENDING_FINAL"]
     E -->|New vote on same proposal<br>triggers scores.ts<br>vp recalculated| B
 
+    B -->|delete-proposal| H["cb = -3<br>PENDING_DELETE"]
+    D -->|delete-proposal| H
+    E -->|delete-proposal| H
+    G -->|delete-proposal| H
+    H -->|deleteProposalVotes.ts<br>async cleanup| I([Vote Deleted])
+
     classDef user fill:#4a90d9,color:#fff
     classDef async fill:#e8833a,color:#fff
 
     class A user
     class F,C async
-    class B,D,E,G default
+    class B,D,E,G,H default
+    class I default
 
     linkStyle 0 stroke:#4a90d9
     linkStyle 1,2,3,4,5 stroke:#e8833a
     linkStyle 6 stroke:#4a90d9
+    linkStyle 7,8,9,10 stroke:#4a90d9
+    linkStyle 11 stroke:#e8833a
 ```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const CB = {
   PENDING_SYNC: 0, // Default db value, waiting from value from overlord
   PENDING_COMPUTE: -1,
   PENDING_FINAL: -2,
+  PENDING_DELETE: -3,
   INELIGIBLE: -10, // Payload format, can not compute
   ERROR_SYNC: -11 // Sync error from overlord, waiting for retry
 };

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -37,30 +37,27 @@ async function processVotes(votes: Vote[]) {
   query.push('DELETE FROM votes WHERE id IN (?)');
   params.push(votes.map(v => v.id));
 
-  await db.queryAsync(query.join(';'), params);
-
-  // Refresh leaderboard from remaining votes (idempotent, single batched query)
+  // Refresh leaderboard from remaining votes (idempotent)
   const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));
-  if (!pairs.size) return;
-
-  const pairPlaceholders = Array.from(pairs)
-    .map(() => '(?, ?)')
-    .join(', ');
-  const pairParams: string[] = [];
-  for (const pair of pairs) {
-    const [voter, space] = pair.split(':');
-    pairParams.push(voter, space);
+  if (pairs.size) {
+    const pairPlaceholders = Array.from(pairs)
+      .map(() => '(?, ?)')
+      .join(', ');
+    query.push(
+      `UPDATE leaderboard l
+        SET vote_count = (SELECT COUNT(*) FROM votes v WHERE v.voter = l.user AND v.space = l.space),
+            vp_value = COALESCE((
+              SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
+            ), 0)
+        WHERE (l.user, l.space) IN (${pairPlaceholders})`
+    );
+    for (const pair of pairs) {
+      const [voter, space] = pair.split(':');
+      params.push(voter, space);
+    }
   }
 
-  await db.queryAsync(
-    `UPDATE leaderboard l
-      SET vote_count = (SELECT COUNT(*) FROM votes v WHERE v.voter = l.user AND v.space = l.space),
-          vp_value = COALESCE((
-            SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
-          ), 0)
-      WHERE (l.user, l.space) IN (${pairPlaceholders})`,
-    pairParams
-  );
+  await db.queryAsync(query.join(';'), params);
 }
 
 export default async function run() {

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -42,7 +42,9 @@ async function processVotes(votes: Vote[]) {
   // Refresh leaderboard from remaining votes (idempotent, single batched query)
   const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));
   if (pairs.size > 0) {
-    const pairPlaceholders = Array.from(pairs).map(() => '(?, ?)').join(', ');
+    const pairPlaceholders = Array.from(pairs)
+      .map(() => '(?, ?)')
+      .join(', ');
     const pairParams: string[] = [];
     for (const pair of pairs) {
       const [voter, space] = pair.split(':');

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -34,8 +34,11 @@ async function processVotes(votes: Vote[]) {
   }
 
   // Delete votes
-  query.push('DELETE FROM votes WHERE id IN (?)');
-  params.push(votes.map(v => v.id));
+  query.push('DELETE FROM votes WHERE id IN (?) AND cb = ?');
+  params.push(
+    votes.map(v => v.id),
+    CB.PENDING_DELETE
+  );
 
   // Refresh leaderboard from remaining votes (idempotent)
   const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -1,0 +1,74 @@
+import snapshot from '@snapshot-labs/snapshot.js';
+import log from './log';
+import db from './mysql';
+import { CB } from '../constants';
+
+type Vote = {
+  id: string;
+  voter: string;
+  space: string;
+  vp_value: number;
+  vp_state: string;
+};
+
+const REFRESH_INTERVAL = 60 * 1000;
+const BATCH_SIZE = 100;
+
+async function getVotesPendingDeletion(): Promise<Vote[]> {
+  return db.queryAsync(
+    `SELECT id, voter, space, vp_value, vp_state FROM votes WHERE cb = ? LIMIT ?`,
+    [CB.PENDING_DELETE, BATCH_SIZE]
+  );
+}
+
+async function processVotes(votes: Vote[]) {
+  const query: string[] = [];
+  const params: (string | number | string[])[] = [];
+
+  // Update spaces vote_count
+  const grouped = new Map<string, Vote[]>();
+  for (const vote of votes) {
+    if (!grouped.has(vote.space)) {
+      grouped.set(vote.space, []);
+    }
+    grouped.get(vote.space)!.push(vote);
+  }
+
+  for (const [space, spaceVotes] of grouped) {
+    query.push('UPDATE spaces SET vote_count = GREATEST(vote_count - ?, 0) WHERE id = ?');
+    params.push(spaceVotes.length, space);
+  }
+
+  // Update leaderboard vote_count and vp_value
+  for (const vote of votes) {
+    query.push(
+      `UPDATE leaderboard
+        SET vote_count = GREATEST(vote_count - 1, 0),
+            vp_value = GREATEST(vp_value - ?, 0)
+        WHERE user = ? AND space = ?`
+    );
+    params.push(vote.vp_state === 'final' ? vote.vp_value : 0, vote.voter, vote.space);
+  }
+
+  // Delete votes
+  query.push('DELETE FROM votes WHERE id IN (?)');
+  params.push(votes.map(v => v.id));
+
+  await db.queryAsync(query.join(';'), params);
+}
+
+export default async function run() {
+  while (true) {
+    const votes = await getVotesPendingDeletion();
+
+    if (votes.length) {
+      log.info(`[deleteProposalVotes] ${votes.length} votes to delete`);
+      await processVotes(votes);
+    }
+
+    if (votes.length < BATCH_SIZE) {
+      log.info('[deleteProposalVotes] sleeping');
+      await snapshot.utils.sleep(REFRESH_INTERVAL);
+    }
+  }
+}

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -24,39 +24,41 @@ async function processVotes(votes: Vote[]) {
   const params: (string | number | string[])[] = [];
 
   // Update spaces vote_count
-  const grouped = new Map<string, Vote[]>();
+  const grouped = new Map<string, number>();
   for (const vote of votes) {
-    if (!grouped.has(vote.space)) {
-      grouped.set(vote.space, []);
-    }
-    grouped.get(vote.space)!.push(vote);
+    grouped.set(vote.space, (grouped.get(vote.space) || 0) + 1);
   }
-
-  for (const [space, spaceVotes] of grouped) {
+  for (const [space, count] of grouped) {
     query.push('UPDATE spaces SET vote_count = GREATEST(vote_count - ?, 0) WHERE id = ?');
-    params.push(spaceVotes.length, space);
+    params.push(count, space);
   }
 
   // Delete votes
   query.push('DELETE FROM votes WHERE id IN (?)');
   params.push(votes.map(v => v.id));
 
-  // Refresh leaderboard from remaining votes (idempotent)
-  const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));
-  for (const pair of pairs) {
-    const [voter, space] = pair.split(':');
-    query.push(
-      `UPDATE leaderboard
-        SET vote_count = (SELECT COUNT(*) FROM votes v WHERE v.voter = ? AND v.space = ?),
-            vp_value = COALESCE((
-              SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = ? AND v.space = ?
-            ), 0)
-        WHERE user = ? AND space = ?`
-    );
-    params.push(voter, space, voter, space, voter, space);
-  }
-
   await db.queryAsync(query.join(';'), params);
+
+  // Refresh leaderboard from remaining votes (idempotent, single batched query)
+  const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));
+  if (pairs.size > 0) {
+    const pairPlaceholders = Array.from(pairs).map(() => '(?, ?)').join(', ');
+    const pairParams: string[] = [];
+    for (const pair of pairs) {
+      const [voter, space] = pair.split(':');
+      pairParams.push(voter, space);
+    }
+
+    await db.queryAsync(
+      `UPDATE leaderboard l
+        SET vote_count = (SELECT COUNT(*) FROM votes v WHERE v.voter = l.user AND v.space = l.space),
+            vp_value = COALESCE((
+              SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
+            ), 0)
+        WHERE (l.user, l.space) IN (${pairPlaceholders})`,
+      pairParams
+    );
+  }
 }
 
 export default async function run() {

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -7,18 +7,16 @@ type Vote = {
   id: string;
   voter: string;
   space: string;
-  vp_value: number;
-  vp_state: string;
 };
 
 const REFRESH_INTERVAL = 60 * 1000;
 const BATCH_SIZE = 100;
 
 async function getVotesPendingDeletion(): Promise<Vote[]> {
-  return db.queryAsync(
-    `SELECT id, voter, space, vp_value, vp_state FROM votes WHERE cb = ? LIMIT ?`,
-    [CB.PENDING_DELETE, BATCH_SIZE]
-  );
+  return db.queryAsync(`SELECT id, voter, space FROM votes WHERE cb = ? LIMIT ?`, [
+    CB.PENDING_DELETE,
+    BATCH_SIZE
+  ]);
 }
 
 async function processVotes(votes: Vote[]) {
@@ -39,20 +37,33 @@ async function processVotes(votes: Vote[]) {
     params.push(spaceVotes.length, space);
   }
 
-  // Update leaderboard vote_count and vp_value
+  // Update leaderboard vote_count
   for (const vote of votes) {
     query.push(
       `UPDATE leaderboard
-        SET vote_count = GREATEST(vote_count - 1, 0),
-            vp_value = GREATEST(vp_value - ?, 0)
+        SET vote_count = GREATEST(vote_count - 1, 0)
         WHERE user = ? AND space = ?`
     );
-    params.push(vote.vp_state === 'final' ? vote.vp_value : 0, vote.voter, vote.space);
+    params.push(vote.voter, vote.space);
   }
 
   // Delete votes
   query.push('DELETE FROM votes WHERE id IN (?)');
   params.push(votes.map(v => v.id));
+
+  // Refresh leaderboard vp_value using SUM from remaining votes (idempotent)
+  const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));
+  for (const pair of pairs) {
+    const [voter, space] = pair.split(':');
+    query.push(
+      `UPDATE leaderboard
+        SET vp_value = COALESCE((
+          SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = ? AND v.space = ?
+        ), 0)
+        WHERE user = ? AND space = ?`
+    );
+    params.push(voter, space, voter, space);
+  }
 
   await db.queryAsync(query.join(';'), params);
 }

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -41,26 +41,26 @@ async function processVotes(votes: Vote[]) {
 
   // Refresh leaderboard from remaining votes (idempotent, single batched query)
   const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));
-  if (pairs.size > 0) {
-    const pairPlaceholders = Array.from(pairs)
-      .map(() => '(?, ?)')
-      .join(', ');
-    const pairParams: string[] = [];
-    for (const pair of pairs) {
-      const [voter, space] = pair.split(':');
-      pairParams.push(voter, space);
-    }
+  if (!pairs.size) return;
 
-    await db.queryAsync(
-      `UPDATE leaderboard l
-        SET vote_count = (SELECT COUNT(*) FROM votes v WHERE v.voter = l.user AND v.space = l.space),
-            vp_value = COALESCE((
-              SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
-            ), 0)
-        WHERE (l.user, l.space) IN (${pairPlaceholders})`,
-      pairParams
-    );
+  const pairPlaceholders = Array.from(pairs)
+    .map(() => '(?, ?)')
+    .join(', ');
+  const pairParams: string[] = [];
+  for (const pair of pairs) {
+    const [voter, space] = pair.split(':');
+    pairParams.push(voter, space);
   }
+
+  await db.queryAsync(
+    `UPDATE leaderboard l
+      SET vote_count = (SELECT COUNT(*) FROM votes v WHERE v.voter = l.user AND v.space = l.space),
+          vp_value = COALESCE((
+            SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
+          ), 0)
+      WHERE (l.user, l.space) IN (${pairPlaceholders})`,
+    pairParams
+  );
 }
 
 export default async function run() {

--- a/src/helpers/deleteProposalVotes.ts
+++ b/src/helpers/deleteProposalVotes.ts
@@ -37,32 +37,23 @@ async function processVotes(votes: Vote[]) {
     params.push(spaceVotes.length, space);
   }
 
-  // Update leaderboard vote_count
-  for (const vote of votes) {
-    query.push(
-      `UPDATE leaderboard
-        SET vote_count = GREATEST(vote_count - 1, 0)
-        WHERE user = ? AND space = ?`
-    );
-    params.push(vote.voter, vote.space);
-  }
-
   // Delete votes
   query.push('DELETE FROM votes WHERE id IN (?)');
   params.push(votes.map(v => v.id));
 
-  // Refresh leaderboard vp_value using SUM from remaining votes (idempotent)
+  // Refresh leaderboard from remaining votes (idempotent)
   const pairs = new Set(votes.map(v => `${v.voter}:${v.space}`));
   for (const pair of pairs) {
     const [voter, space] = pair.split(':');
     query.push(
       `UPDATE leaderboard
-        SET vp_value = COALESCE((
-          SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = ? AND v.space = ?
-        ), 0)
+        SET vote_count = (SELECT COUNT(*) FROM votes v WHERE v.voter = ? AND v.space = ?),
+            vp_value = COALESCE((
+              SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = ? AND v.space = ?
+            ), 0)
         WHERE user = ? AND space = ?`
     );
-    params.push(voter, space, voter, space);
+    params.push(voter, space, voter, space, voter, space);
   }
 
   await db.queryAsync(query.join(';'), params);

--- a/src/helpers/shutter.ts
+++ b/src/helpers/shutter.ts
@@ -6,6 +6,7 @@ import express from 'express';
 import log from './log';
 import db from './mysql';
 import { getIp, jsonParse, jsonRpcRequest, rpcError, rpcSuccess } from './utils';
+import { CB } from '../constants';
 import { updateProposalAndVotes } from '../scores';
 
 init().then(() => log.info('[shutter] init'));
@@ -58,8 +59,8 @@ export async function setProposalKey(params) {
     const ts = (Date.now() / 1e3).toFixed();
     if (!proposal || ts < proposal.end) return false;
 
-    query = 'SELECT id, choice FROM votes WHERE proposal = ?';
-    const votes = await db.queryAsync(query, [proposal.id]);
+    query = 'SELECT id, choice FROM votes WHERE proposal = ? AND cb != ?';
+    const votes = await db.queryAsync(query, [proposal.id, CB.PENDING_DELETE]);
 
     const sqlParams: string[] = [];
     let sqlQuery = '';

--- a/src/helpers/votesVpValue.ts
+++ b/src/helpers/votesVpValue.ts
@@ -153,28 +153,25 @@ async function refreshVotesVpValues(data: Datum[]) {
   ];
   const params: (number | string)[] = [...vpParams, ...cbParams, ...ids];
 
-  await db.queryAsync(queries.join(';'), params);
-
   // Refresh leaderboard vp_value using SUM from votes table (idempotent)
-  if (!leaderboardPairs.size) return;
-
-  const pairPlaceholders = Array.from(leaderboardPairs)
-    .map(() => '(?, ?)')
-    .join(', ');
-  const pairParams: string[] = [];
-  for (const pair of leaderboardPairs) {
-    const [voter, space] = pair.split(':');
-    pairParams.push(voter, space);
+  if (leaderboardPairs.size) {
+    const pairPlaceholders = Array.from(leaderboardPairs)
+      .map(() => '(?, ?)')
+      .join(', ');
+    queries.push(
+      `UPDATE leaderboard l
+        SET vp_value = COALESCE((
+          SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
+        ), 0)
+        WHERE (l.user, l.space) IN (${pairPlaceholders})`
+    );
+    for (const pair of leaderboardPairs) {
+      const [voter, space] = pair.split(':');
+      params.push(voter, space);
+    }
   }
 
-  await db.queryAsync(
-    `UPDATE leaderboard l
-      SET vp_value = COALESCE((
-        SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
-      ), 0)
-      WHERE (l.user, l.space) IN (${pairPlaceholders})`,
-    pairParams
-  );
+  await db.queryAsync(queries.join(';'), params);
 }
 
 async function processBatch(proposalVpValues: ProposalVpValues): Promise<number> {

--- a/src/helpers/votesVpValue.ts
+++ b/src/helpers/votesVpValue.ts
@@ -149,9 +149,9 @@ async function refreshVotesVpValues(data: Datum[]) {
   }
 
   const queries: string[] = [
-    `UPDATE votes SET vp_value = CASE ${vpCases} END, cb = CASE ${cbCases} END WHERE id IN (${placeholders})`
+    `UPDATE votes SET vp_value = CASE ${vpCases} END, cb = CASE ${cbCases} END WHERE id IN (${placeholders}) AND cb = ?`
   ];
-  const params: (number | string)[] = [...vpParams, ...cbParams, ...ids];
+  const params: (number | string)[] = [...vpParams, ...cbParams, ...ids, CB.PENDING_COMPUTE];
 
   // Refresh leaderboard vp_value using SUM from votes table (idempotent)
   if (leaderboardPairs.size) {

--- a/src/helpers/votesVpValue.ts
+++ b/src/helpers/votesVpValue.ts
@@ -15,7 +15,6 @@ type Datum = {
   vpByStrategy: number[];
   vpValueByStrategy: number[];
   proposalCb: number;
-  vpValue: number;
 };
 
 const REFRESH_INTERVAL = 60 * 1000;
@@ -43,11 +42,10 @@ async function getPendingVotes(): Promise<
     proposal: string;
     vpState: string;
     vpByStrategy: number[];
-    vpValue: number;
   }[]
 > {
   const query = `
-    SELECT id, voter, space, proposal, vp_state, vp_by_strategy, vp_value
+    SELECT id, voter, space, proposal, vp_state, vp_by_strategy
     FROM votes
     WHERE cb = ?
     LIMIT ?`;
@@ -59,8 +57,7 @@ async function getPendingVotes(): Promise<
     space: r.space,
     proposal: r.proposal,
     vpState: r.vp_state,
-    vpByStrategy: JSON.parse(r.vp_by_strategy),
-    vpValue: r.vp_value || 0
+    vpByStrategy: JSON.parse(r.vp_by_strategy)
   }));
 }
 
@@ -104,7 +101,7 @@ async function refreshVotesVpValues(data: Datum[]) {
   const ids: string[] = [];
   const vpValues: Map<string, number> = new Map();
   const cbValues: Map<string, number> = new Map();
-  const leaderboardUpdates: { value: number; voter: string; space: string }[] = [];
+  const leaderboardPairs: Set<string> = new Set();
 
   for (const datum of data) {
     if (datum.proposalCb === CB.INELIGIBLE) {
@@ -128,16 +125,7 @@ async function refreshVotesVpValues(data: Datum[]) {
         validatedDatum.vpState === 'final' ? CB.FINAL : CB.PENDING_FINAL
       );
 
-      // Leaderboard update only for final votes
-      // to avoid vp fluctuations with overriding strategies
-      // Use delta (new - old) to handle re-votes correctly
-      if (validatedDatum.vpState === 'final') {
-        leaderboardUpdates.push({
-          value: value - datum.vpValue,
-          voter: validatedDatum.voter,
-          space: validatedDatum.space
-        });
-      }
+      leaderboardPairs.add(`${validatedDatum.voter}:${validatedDatum.space}`);
     } catch (e) {
       capture(e);
       ids.push(datum.id);
@@ -165,13 +153,17 @@ async function refreshVotesVpValues(data: Datum[]) {
   ];
   const params: (number | string)[] = [...vpParams, ...cbParams, ...ids];
 
-  for (const update of leaderboardUpdates) {
+  // Refresh leaderboard vp_value using SUM from votes table (idempotent)
+  for (const pair of leaderboardPairs) {
+    const [voter, space] = pair.split(':');
     queries.push(
       `UPDATE leaderboard
-        SET vp_value = vp_value + ?
+        SET vp_value = COALESCE((
+          SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = ? AND v.space = ?
+        ), 0)
         WHERE user = ? AND space = ?`
     );
-    params.push(update.value, update.voter, update.space);
+    params.push(voter, space, voter, space);
   }
 
   await db.queryAsync(queries.join(';'), params);
@@ -192,8 +184,7 @@ async function processBatch(proposalVpValues: ProposalVpValues): Promise<number>
         vpState: v.vpState,
         vpByStrategy: v.vpByStrategy,
         vpValueByStrategy: proposal.vpValueByStrategy,
-        proposalCb: proposal.cb,
-        vpValue: v.vpValue
+        proposalCb: proposal.cb
       };
     });
 

--- a/src/helpers/votesVpValue.ts
+++ b/src/helpers/votesVpValue.ts
@@ -9,6 +9,8 @@ type ProposalVpValues = Map<string, { cb: number; vpValueByStrategy: number[] }>
 
 type Datum = {
   id: string;
+  voter: string;
+  space: string;
   vpState: string;
   vpByStrategy: number[];
   vpValueByStrategy: number[];
@@ -22,6 +24,8 @@ const PROPOSALS_BATCH_SIZE = 50000;
 const datumSchema = z
   .object({
     id: z.string(),
+    voter: z.string(),
+    space: z.string(),
     vpState: z.string(),
     vpValueByStrategy: z.array(z.number().finite()),
     vpByStrategy: z.array(z.number().finite())
@@ -31,10 +35,17 @@ const datumSchema = z
   });
 
 async function getPendingVotes(): Promise<
-  { id: string; proposal: string; vpState: string; vpByStrategy: number[] }[]
+  {
+    id: string;
+    voter: string;
+    space: string;
+    proposal: string;
+    vpState: string;
+    vpByStrategy: number[];
+  }[]
 > {
   const query = `
-    SELECT id, proposal, vp_state, vp_by_strategy
+    SELECT id, voter, space, proposal, vp_state, vp_by_strategy
     FROM votes
     WHERE cb = ?
     LIMIT ?`;
@@ -42,6 +53,8 @@ async function getPendingVotes(): Promise<
 
   return results.map((r: any) => ({
     id: r.id,
+    voter: r.voter,
+    space: r.space,
     proposal: r.proposal,
     vpState: r.vp_state,
     vpByStrategy: JSON.parse(r.vp_by_strategy)
@@ -88,6 +101,7 @@ async function refreshVotesVpValues(data: Datum[]) {
   const ids: string[] = [];
   const vpValues: Map<string, number> = new Map();
   const cbValues: Map<string, number> = new Map();
+  const leaderboardUpdates: { value: number; voter: string; space: string }[] = [];
 
   for (const datum of data) {
     if (datum.proposalCb === CB.INELIGIBLE) {
@@ -110,6 +124,16 @@ async function refreshVotesVpValues(data: Datum[]) {
         validatedDatum.id,
         validatedDatum.vpState === 'final' ? CB.FINAL : CB.PENDING_FINAL
       );
+
+      // Leaderboard update only for final votes
+      // to avoid vp fluctuations with overriding strategies
+      if (validatedDatum.vpState === 'final') {
+        leaderboardUpdates.push({
+          value,
+          voter: validatedDatum.voter,
+          space: validatedDatum.space
+        });
+      }
     } catch (e) {
       capture(e);
       ids.push(datum.id);
@@ -132,8 +156,21 @@ async function refreshVotesVpValues(data: Datum[]) {
     cbParams.push(id, cbValues.get(id)!);
   }
 
-  const query = `UPDATE votes SET vp_value = CASE ${vpCases} END, cb = CASE ${cbCases} END WHERE id IN (${placeholders})`;
-  await db.queryAsync(query, [...vpParams, ...cbParams, ...ids]);
+  const queries: string[] = [
+    `UPDATE votes SET vp_value = CASE ${vpCases} END, cb = CASE ${cbCases} END WHERE id IN (${placeholders})`
+  ];
+  const params: (number | string)[] = [...vpParams, ...cbParams, ...ids];
+
+  for (const update of leaderboardUpdates) {
+    queries.push(
+      `UPDATE leaderboard
+        SET vp_value = vp_value + ?
+        WHERE user = ? AND space = ?`
+    );
+    params.push(update.value, update.voter, update.space);
+  }
+
+  await db.queryAsync(queries.join(';'), params);
 }
 
 async function processBatch(proposalVpValues: ProposalVpValues): Promise<number> {
@@ -146,6 +183,8 @@ async function processBatch(proposalVpValues: ProposalVpValues): Promise<number>
       const proposal = proposalVpValues.get(v.proposal)!;
       return {
         id: v.id,
+        voter: v.voter,
+        space: v.space,
         vpState: v.vpState,
         vpByStrategy: v.vpByStrategy,
         vpValueByStrategy: proposal.vpValueByStrategy,

--- a/src/helpers/votesVpValue.ts
+++ b/src/helpers/votesVpValue.ts
@@ -156,25 +156,25 @@ async function refreshVotesVpValues(data: Datum[]) {
   await db.queryAsync(queries.join(';'), params);
 
   // Refresh leaderboard vp_value using SUM from votes table (idempotent)
-  if (leaderboardPairs.size > 0) {
-    const pairPlaceholders = Array.from(leaderboardPairs)
-      .map(() => '(?, ?)')
-      .join(', ');
-    const pairParams: string[] = [];
-    for (const pair of leaderboardPairs) {
-      const [voter, space] = pair.split(':');
-      pairParams.push(voter, space);
-    }
+  if (!leaderboardPairs.size) return;
 
-    await db.queryAsync(
-      `UPDATE leaderboard l
-        SET vp_value = COALESCE((
-          SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
-        ), 0)
-        WHERE (l.user, l.space) IN (${pairPlaceholders})`,
-      pairParams
-    );
+  const pairPlaceholders = Array.from(leaderboardPairs)
+    .map(() => '(?, ?)')
+    .join(', ');
+  const pairParams: string[] = [];
+  for (const pair of leaderboardPairs) {
+    const [voter, space] = pair.split(':');
+    pairParams.push(voter, space);
   }
+
+  await db.queryAsync(
+    `UPDATE leaderboard l
+      SET vp_value = COALESCE((
+        SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
+      ), 0)
+      WHERE (l.user, l.space) IN (${pairPlaceholders})`,
+    pairParams
+  );
 }
 
 async function processBatch(proposalVpValues: ProposalVpValues): Promise<number> {

--- a/src/helpers/votesVpValue.ts
+++ b/src/helpers/votesVpValue.ts
@@ -153,20 +153,28 @@ async function refreshVotesVpValues(data: Datum[]) {
   ];
   const params: (number | string)[] = [...vpParams, ...cbParams, ...ids];
 
-  // Refresh leaderboard vp_value using SUM from votes table (idempotent)
-  for (const pair of leaderboardPairs) {
-    const [voter, space] = pair.split(':');
-    queries.push(
-      `UPDATE leaderboard
-        SET vp_value = COALESCE((
-          SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = ? AND v.space = ?
-        ), 0)
-        WHERE user = ? AND space = ?`
-    );
-    params.push(voter, space, voter, space);
-  }
-
   await db.queryAsync(queries.join(';'), params);
+
+  // Refresh leaderboard vp_value using SUM from votes table (idempotent)
+  if (leaderboardPairs.size > 0) {
+    const pairPlaceholders = Array.from(leaderboardPairs)
+      .map(() => '(?, ?)')
+      .join(', ');
+    const pairParams: string[] = [];
+    for (const pair of leaderboardPairs) {
+      const [voter, space] = pair.split(':');
+      pairParams.push(voter, space);
+    }
+
+    await db.queryAsync(
+      `UPDATE leaderboard l
+        SET vp_value = COALESCE((
+          SELECT SUM(v.vp_value) FROM votes v WHERE v.voter = l.user AND v.space = l.space
+        ), 0)
+        WHERE (l.user, l.space) IN (${pairPlaceholders})`,
+      pairParams
+    );
+  }
 }
 
 async function processBatch(proposalVpValues: ProposalVpValues): Promise<number> {

--- a/src/helpers/votesVpValue.ts
+++ b/src/helpers/votesVpValue.ts
@@ -15,6 +15,7 @@ type Datum = {
   vpByStrategy: number[];
   vpValueByStrategy: number[];
   proposalCb: number;
+  vpValue: number;
 };
 
 const REFRESH_INTERVAL = 60 * 1000;
@@ -42,10 +43,11 @@ async function getPendingVotes(): Promise<
     proposal: string;
     vpState: string;
     vpByStrategy: number[];
+    vpValue: number;
   }[]
 > {
   const query = `
-    SELECT id, voter, space, proposal, vp_state, vp_by_strategy
+    SELECT id, voter, space, proposal, vp_state, vp_by_strategy, vp_value
     FROM votes
     WHERE cb = ?
     LIMIT ?`;
@@ -57,7 +59,8 @@ async function getPendingVotes(): Promise<
     space: r.space,
     proposal: r.proposal,
     vpState: r.vp_state,
-    vpByStrategy: JSON.parse(r.vp_by_strategy)
+    vpByStrategy: JSON.parse(r.vp_by_strategy),
+    vpValue: r.vp_value || 0
   }));
 }
 
@@ -127,9 +130,10 @@ async function refreshVotesVpValues(data: Datum[]) {
 
       // Leaderboard update only for final votes
       // to avoid vp fluctuations with overriding strategies
+      // Use delta (new - old) to handle re-votes correctly
       if (validatedDatum.vpState === 'final') {
         leaderboardUpdates.push({
-          value,
+          value: value - datum.vpValue,
           voter: validatedDatum.voter,
           space: validatedDatum.space
         });
@@ -188,7 +192,8 @@ async function processBatch(proposalVpValues: ProposalVpValues): Promise<number>
         vpState: v.vpState,
         vpByStrategy: v.vpByStrategy,
         vpValueByStrategy: proposal.vpValueByStrategy,
-        proposalCb: proposal.cb
+        proposalCb: proposal.cb,
+        vpValue: v.vpValue
       };
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { fallbackLogger, initLogger } from '@snapshot-labs/snapshot-sentry';
 import cors from 'cors';
 import express from 'express';
 import api from './api';
+import deleteProposalVotes from './helpers/deleteProposalVotes';
 import log from './helpers/log';
 import initMetrics from './helpers/metrics';
 import refreshModeration from './helpers/moderation';
@@ -26,6 +27,7 @@ async function startServer() {
   refreshProposalsVpValue();
   refreshProposalsScoresValue();
   refreshVotesVpValue();
+  deleteProposalVotes();
 
   await initializeStrategies();
   refreshStrategies();

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -62,7 +62,7 @@ async function updateVotesVp(votes: any[], vpState: string, proposalId: string) 
     votesInPage.forEach((vote: any) => {
       query += `UPDATE votes
       SET vp = ?, vp_by_strategy = ?, vp_state = ?, vp_value = ?, cb = ?
-      WHERE id = ? AND proposal = ? LIMIT 1; `;
+      WHERE id = ? AND proposal = ? AND cb != ? LIMIT 1; `;
       params.push(vote.balance);
       params.push(JSON.stringify(vote.scores));
       params.push(vpState);
@@ -70,6 +70,7 @@ async function updateVotesVp(votes: any[], vpState: string, proposalId: string) 
       params.push(CB.PENDING_COMPUTE);
       params.push(vote.id);
       params.push(proposalId);
+      params.push(CB.PENDING_DELETE);
     });
     await db.queryAsync(query, params);
     if (i) await snapshot.utils.sleep(200);

--- a/src/writer/delete-proposal.ts
+++ b/src/writer/delete-proposal.ts
@@ -1,3 +1,4 @@
+import { CB } from '../constants';
 import { getProposal, getSpace } from '../helpers/actions';
 import db from '../helpers/mysql';
 import { jsonParse } from '../helpers/utils';
@@ -21,36 +22,19 @@ export async function verify(body): Promise<any> {
 export async function action(body): Promise<void> {
   const msg = jsonParse(body.msg);
   const proposal = await getProposal(msg.space, msg.payload.proposal);
-
-  const voters = await db.queryAsync(`SELECT voter FROM votes WHERE proposal = ?`, [
-    msg.payload.proposal
-  ]);
   const id = msg.payload.proposal;
 
-  let queries = `
+  const queries = `
     DELETE FROM proposals WHERE id = ? LIMIT 1;
-    DELETE FROM votes WHERE proposal = ?;
+    UPDATE votes SET cb = ? WHERE proposal = ?;
     UPDATE leaderboard
       SET proposal_count = GREATEST(proposal_count - 1, 0)
       WHERE user = ? AND space = ?
       LIMIT 1;
     UPDATE spaces
-      SET proposal_count = GREATEST(proposal_count - 1, 0), vote_count = GREATEST(vote_count - ?, 0)
+      SET proposal_count = GREATEST(proposal_count - 1, 0)
       WHERE id = ?;
   `;
 
-  const parameters = [id, id, proposal.author, msg.space, voters.length, msg.space];
-
-  if (voters.length > 0) {
-    queries += `
-    UPDATE leaderboard SET vote_count = GREATEST(vote_count - 1, 0)
-      WHERE user IN (?) AND space = ?;
-  `;
-    parameters.push(
-      voters.map(voter => voter.voter),
-      msg.space
-    );
-  }
-
-  await db.queryAsync(queries, parameters);
+  await db.queryAsync(queries, [id, CB.PENDING_DELETE, id, proposal.author, msg.space, msg.space]);
 }

--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -182,8 +182,8 @@ export async function action(body, ipfs, receipt, id, context): Promise<void> {
     await db.queryAsync(
       `
         INSERT INTO votes SET ?;
-        INSERT INTO leaderboard (space, user, vote_count, last_vote)
-          VALUES(?, ?, 1, ?)
+        INSERT INTO leaderboard (space, user, vote_count, last_vote, vp_value)
+          VALUES(?, ?, 1, ?, 0)
           ON DUPLICATE KEY UPDATE vote_count = vote_count + 1, last_vote = ?;
         UPDATE spaces SET vote_count = vote_count + 1 WHERE id = ?;
       `,

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -192,11 +192,13 @@ CREATE TABLE leaderboard (
   vote_count SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   proposal_count SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   last_vote BIGINT,
+  vp_value DECIMAL(13,3) NOT NULL DEFAULT 0.000,
   PRIMARY KEY user_space (user,space),
   INDEX space (space),
   INDEX vote_count (vote_count),
   INDEX proposal_count (proposal_count),
-  INDEX last_vote (last_vote)
+  INDEX last_vote (last_vote),
+  INDEX vp_value (vp_value)
 );
 
 CREATE TABLE skins (


### PR DESCRIPTION
## Summary

Adds `vp_value` tracking to the leaderboard table and defers vote deletion to an async background script. Leaderboard updates use idempotent SUM/COUNT queries from the votes table instead of fragile delta-based increments, preventing drift from re-votes, race conditions, or missed updates.

Background workers (`votesVpValue`, `scores`, `shutter`) now guard against overwriting `cb=PENDING_DELETE` set by `delete-proposal`, preventing a race condition where votes marked for deletion could be orphaned.

## Changes

- ✨ Add `vp_value` column to the `leaderboard` table
- ✨ Add `PENDING_DELETE` constant (`cb = -3`) for soft-deleting votes
- ✨ Add `deleteProposalVotes` async script to process pending vote deletions in batches
- ♻️ `delete-proposal` writer: mark votes as `PENDING_DELETE` instead of deleting inline
- ♻️ `votesVpValue`: refresh leaderboard `vp_value` using `SUM(vp_value)` from votes table (idempotent)
- ♻️ `deleteProposalVotes`: refresh leaderboard `vote_count` and `vp_value` using `COUNT(*)`/`SUM()` via single JOIN subquery (idempotent)
- 🐛 `votesVpValue`: guard vote `cb` update with `AND cb = PENDING_COMPUTE` to prevent overwriting `PENDING_DELETE`
- 🐛 `scores`: guard vote update with `AND cb != PENDING_DELETE` to prevent overwriting deletion state
- 🐛 `shutter`: skip `PENDING_DELETE` votes during decryption to avoid wasted work and inconsistency

## Benchmark

Tested against production database (68M+ votes). All queries use the PRIMARY KEY `(voter, space, proposal)` index.

| Query | Time |
|---|---|
| `SUM(vp_value) WHERE voter+space` (single pair) | ~500ms |
| Batch leaderboard refresh (50 pairs) | 1,123ms |
| Batch leaderboard refresh (200 pairs) | 797ms |
| Batch leaderboard refresh (500 pairs) | 1,355ms |

~500ms is mostly network latency to PlanetScale. The query itself is near-instant (PK index lookup).

## Test plan

- [ ] Verify `vp_value` column is added to leaderboard table
- [ ] Verify votes are marked `cb = -3` on proposal deletion instead of being deleted inline
- [ ] Verify `deleteProposalVotes` script picks up and deletes pending votes
- [ ] Verify leaderboard `vp_value` is refreshed correctly after vote vp_value computation
- [ ] Verify leaderboard `vote_count` and `vp_value` are correct after vote deletion
- [ ] Verify background workers do not overwrite `PENDING_DELETE` on votes mid-deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)