### PR TITLE
fix: ignore vote vp_value computation when proposal vp_value is empty

### DIFF
--- a/src/helpers/entityValue.ts
+++ b/src/helpers/entityValue.ts
@@ -11,6 +11,8 @@ type Proposal = {
  * @returns The total vote value, in the currency unit specified by the proposal's vp_value_by_strategy values
  **/
 export function getVoteValue(proposal: Proposal, vote: Vote): number {
+  if (!proposal.vp_value_by_strategy.length) return 0;
+
   if (proposal.vp_value_by_strategy.length !== vote.vp_by_strategy.length) {
     throw new Error('invalid data to compute vote value');
   }


### PR DESCRIPTION
When the proposal `vp_value_by_strategy` is empty, the vp value computation is throwing an error. 

This is to catch any error when the both arrays size does not match, but we should ignore this when the array is empty, to prevent noise in the error logs.

This PR will throw an error only when the array is not empty, and with size not matching