### PR TITLE
feat(overlord): compute proposal's `scores_total_value`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "ts-node": "^10.9.1",
     "turndown": "^7.2.0",
     "typescript": "^4.7.4",
-    "winston": "^3.8.2"
+    "winston": "^3.8.2",
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0-beta.18",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ export const CB = {
   FINAL: 1,
   PENDING_SYNC: 0, // Default db value, waiting from value from overlord
   PENDING_COMPUTE: -1,
-  PENDING_CLOSE: -2,
+  PENDING_FINAL: -2,
   INELIGIBLE: -10, // Payload format, can not compute
   ERROR_SYNC: -11 // Sync error from overlord, waiting for retry
 };

--- a/src/helpers/entityValue.ts
+++ b/src/helpers/entityValue.ts
@@ -45,3 +45,46 @@ export function getVoteValue(proposal: { vp_value_by_strategy: number[] }, vote:
     0
   );
 }
+
+/**
+ * Calculates the proposal total value based on all votes' total voting power and the proposal's value per strategy.
+ * @returns The total value of the given proposal's votes, in the currency unit specified by the proposal's vp_value_by_strategy values
+ */
+export function getProposalValue(
+  scoresByStrategy: number[][],
+  vpValueByStrategy: number[]
+): number {
+  if (!scoresByStrategy.length || !scoresByStrategy[0]?.length || !vpValueByStrategy.length) {
+    return 0;
+  }
+
+  // Validate that all voteScores arrays have the same length as vpValueByStrategy
+  for (const voteScores of scoresByStrategy) {
+    if (voteScores.length !== vpValueByStrategy.length) {
+      throw new Error(
+        'Array size mismatch: voteScores length does not match vpValueByStrategy length'
+      );
+    }
+  }
+
+  let totalValue = 0;
+  for (let strategyIndex = 0; strategyIndex < vpValueByStrategy.length; strategyIndex++) {
+    const strategyTotal = scoresByStrategy.reduce((sum, voteScores) => {
+      const score = voteScores[strategyIndex];
+      if (typeof score !== 'number') {
+        throw new Error(`Invalid score value: expected number, got ${typeof score}`);
+      }
+      return sum + score;
+    }, 0);
+
+    if (typeof vpValueByStrategy[strategyIndex] !== 'number') {
+      throw new Error(
+        `Invalid vp_value: expected number, got ${typeof vpValueByStrategy[strategyIndex]}`
+      );
+    }
+
+    totalValue += strategyTotal * vpValueByStrategy[strategyIndex];
+  }
+
+  return totalValue;
+}

--- a/src/helpers/entityValue.ts
+++ b/src/helpers/entityValue.ts
@@ -54,7 +54,7 @@ export function getProposalValue(
   scoresByStrategy: number[][],
   vpValueByStrategy: number[]
 ): number {
-  if (!scoresByStrategy.length || !scoresByStrategy[0]?.length || !vpValueByStrategy.length) {
+  if (!scoresByStrategy.length || !scoresByStrategy[0].length || !vpValueByStrategy.length) {
     return 0;
   }
 

--- a/src/helpers/entityValue.ts
+++ b/src/helpers/entityValue.ts
@@ -45,36 +45,3 @@ export function getVoteValue(proposal: { vp_value_by_strategy: number[] }, vote:
     0
   );
 }
-
-/**
- * Calculates the proposal total value based on all votes' total voting power and the proposal's value per strategy.
- * @returns The total value of the given proposal's votes, in the currency unit specified by the proposal's vp_value_by_strategy values
- */
-export function getProposalValue(
-  scoresByStrategy: number[][],
-  vpValueByStrategy: number[]
-): number {
-  if (!scoresByStrategy.length || !scoresByStrategy[0].length || !vpValueByStrategy.length) {
-    return 0;
-  }
-
-  // Validate that all voteScores arrays have the same length as vpValueByStrategy
-  for (const voteScores of scoresByStrategy) {
-    if (voteScores.length !== vpValueByStrategy.length) {
-      throw new Error(
-        'Array size mismatch: voteScores length does not match vpValueByStrategy length'
-      );
-    }
-  }
-
-  let totalValue = 0;
-  for (let strategyIndex = 0; strategyIndex < vpValueByStrategy.length; strategyIndex++) {
-    const strategyTotal = scoresByStrategy.reduce((sum, voteScores) => {
-      return sum + voteScores[strategyIndex];
-    }, 0);
-
-    totalValue += strategyTotal * vpValueByStrategy[strategyIndex];
-  }
-
-  return totalValue;
-}

--- a/src/helpers/entityValue.ts
+++ b/src/helpers/entityValue.ts
@@ -70,18 +70,8 @@ export function getProposalValue(
   let totalValue = 0;
   for (let strategyIndex = 0; strategyIndex < vpValueByStrategy.length; strategyIndex++) {
     const strategyTotal = scoresByStrategy.reduce((sum, voteScores) => {
-      const score = voteScores[strategyIndex];
-      if (typeof score !== 'number') {
-        throw new Error(`Invalid score value: expected number, got ${typeof score}`);
-      }
-      return sum + score;
+      return sum + voteScores[strategyIndex];
     }, 0);
-
-    if (typeof vpValueByStrategy[strategyIndex] !== 'number') {
-      throw new Error(
-        `Invalid vp_value: expected number, got ${typeof vpValueByStrategy[strategyIndex]}`
-      );
-    }
 
     totalValue += strategyTotal * vpValueByStrategy[strategyIndex];
   }

--- a/src/helpers/proposalsScoresValue.ts
+++ b/src/helpers/proposalsScoresValue.ts
@@ -44,7 +44,7 @@ async function getProposals(): Promise<Proposal[]> {
     ORDER BY created ASC
     LIMIT ?
   `;
-  const proposals = await db.queryAsync(query, [CB.PENDING_CLOSE, BATCH_SIZE]);
+  const proposals = await db.queryAsync(query, [CB.PENDING_COMPUTE, BATCH_SIZE]);
 
   return proposals.map((p: any) => ({
     id: p.id,
@@ -77,7 +77,7 @@ async function refreshProposalsScoresTotalValue(proposals: Proposal[]) {
       const scoresTotalValue = getScoresTotalValue(proposal);
       params.push(
         scoresTotalValue,
-        proposal.scoresState === 'final' ? CB.FINAL : CB.PENDING_CLOSE,
+        proposal.scoresState === 'final' ? CB.FINAL : CB.PENDING_FINAL,
         proposal.id
       );
     } catch (e) {

--- a/src/helpers/proposalsScoresValue.ts
+++ b/src/helpers/proposalsScoresValue.ts
@@ -1,0 +1,69 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import snapshot from '@snapshot-labs/snapshot.js';
+import { getProposalValue } from './entityValue';
+import db from './mysql';
+import { CB } from '../constants';
+
+type Proposal = {
+  id: string;
+  vpValueByStrategy: number[];
+  scoresByStrategy: number[][];
+};
+
+const REFRESH_INTERVAL = 10 * 1000;
+const BATCH_SIZE = 25;
+
+async function getProposals(): Promise<Proposal[]> {
+  const query = `
+    SELECT id, vp_value_by_strategy, scores_by_strategy
+    FROM proposals
+    WHERE cb = ? AND end < UNIX_TIMESTAMP() AND scores_state = ?
+    ORDER BY created ASC
+    LIMIT ?
+  `;
+  const proposals = await db.queryAsync(query, [CB.PENDING_CLOSE, 'final', BATCH_SIZE]);
+
+  return proposals.map((p: any) => ({
+    id: p.id,
+    vpValueByStrategy: JSON.parse(p.vp_value_by_strategy),
+    scoresByStrategy: JSON.parse(p.scores_by_strategy)
+  }));
+}
+
+async function refreshScoresTotal(proposals: Proposal[]) {
+  const query: string[] = [];
+  const params: any[] = [];
+
+  proposals.map(proposal => {
+    query.push('UPDATE proposals SET scores_total_value = ?, cb = ? WHERE id = ? LIMIT 1');
+
+    try {
+      const scoresTotalValue = getProposalValue(
+        proposal.scoresByStrategy,
+        proposal.vpValueByStrategy
+      );
+      params.push(scoresTotalValue, CB.FINAL, proposal.id);
+    } catch (e) {
+      capture(e);
+      params.push(0, CB.INELIGIBLE, proposal.id);
+    }
+  });
+
+  if (query.length) {
+    await db.queryAsync(query.join(';'), params);
+  }
+}
+
+export default async function run() {
+  while (true) {
+    const proposals = await getProposals();
+
+    if (proposals.length) {
+      await refreshScoresTotal(proposals);
+    }
+
+    if (proposals.length < BATCH_SIZE) {
+      await snapshot.utils.sleep(REFRESH_INTERVAL);
+    }
+  }
+}

--- a/src/helpers/proposalsScoresValue.ts
+++ b/src/helpers/proposalsScoresValue.ts
@@ -34,7 +34,7 @@ async function refreshScoresTotal(proposals: Proposal[]) {
   const query: string[] = [];
   const params: any[] = [];
 
-  proposals.map(proposal => {
+  proposals.forEach(proposal => {
     query.push('UPDATE proposals SET scores_total_value = ?, cb = ? WHERE id = ? LIMIT 1');
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import api from './api';
 import log from './helpers/log';
 import initMetrics from './helpers/metrics';
 import refreshModeration from './helpers/moderation';
+import refreshProposalsScoresValue from './helpers/proposalsScoresValue';
 import refreshProposalsVpValue from './helpers/proposalStrategiesValue';
 import rateLimit from './helpers/rateLimit';
 import shutter from './helpers/shutter';
@@ -22,6 +23,7 @@ async function startServer() {
   initLogger(app);
   refreshModeration();
   refreshProposalsVpValue();
+  refreshProposalsScoresValue();
 
   await initializeStrategies();
   refreshStrategies();

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -1,4 +1,5 @@
 import snapshot from '@snapshot-labs/snapshot.js';
+import { CB } from './constants';
 import { getVoteValue } from './helpers/entityValue';
 import log from './helpers/log';
 import db from './helpers/mysql';
@@ -86,7 +87,8 @@ async function updateProposalScores(proposalId: string, scores: any, votes: numb
     scores_by_strategy = ?,
     scores_total = ?,
     scores_updated = ?,
-    votes = ?
+    votes = ?,
+    cb = ?
     WHERE id = ? LIMIT 1;
   `;
   await db.queryAsync(query, [
@@ -96,6 +98,7 @@ async function updateProposalScores(proposalId: string, scores: any, votes: numb
     scores.scores_total,
     ts,
     votes,
+    CB.PENDING_COMPUTE,
     proposalId
   ]);
 }

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -78,7 +78,7 @@ async function updateVotesVp(votes: any[], vpState: string, proposalId: string) 
   log.info(`[scores] updated votes vp, ${votesWithChange.length}/${votes.length} on ${proposalId}`);
 }
 
-async function updateProposalScores(proposalId: string, scores: any, votes: number) {
+async function updateProposalScores(proposal: any, scores: any, votes: number) {
   const ts = (Date.now() / 1e3).toFixed();
   const query = `
     UPDATE proposals
@@ -98,8 +98,8 @@ async function updateProposalScores(proposalId: string, scores: any, votes: numb
     scores.scores_total,
     ts,
     votes,
-    CB.PENDING_COMPUTE,
-    proposalId
+    proposal.cb === CB.PENDING_FINAL ? CB.PENDING_COMPUTE : proposal.cb,
+    proposal.id
   ]);
 }
 
@@ -187,7 +187,7 @@ export async function updateProposalAndVotes(proposalId: string, force = false) 
     if (!isFinal) await updateVotesVp(votes, vpState, proposalId);
 
     // Store scores
-    await updateProposalScores(proposalId, results, votes.length);
+    await updateProposalScores(proposal, results, votes.length);
     log.info(
       `[scores] Proposal updated ${proposal.id}, ${proposal.space}, ${results.scores_state}, ${votes.length}`
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6042,3 +6042,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
In continuation of https://github.com/snapshot-labs/snapshot-sequencer/pull/593

This PR will set the proposal's scores_total_value with an async script

It's using a simple local computation, to get the total value, from existing data, only on closed proposals, and with final scores_state.