### PR TITLE
fix: allow alias renewal by re-submitting existing pair

### DIFF
--- a/src/writer/alias.ts
+++ b/src/writer/alias.ts
@@ -10,9 +10,10 @@ export async function verify(message): Promise<any> {
     log.warn(`[writer] Wrong alias format ${JSON.stringify(schemaIsValid)}`);
     return Promise.reject('wrong alias format');
   }
-  if (message.from === msg.payload.alias) {
+  if (message.address === msg.payload.alias) {
     return Promise.reject('alias cannot be the same as the address');
   }
+
   return true;
 }
 
@@ -25,5 +26,8 @@ export async function action(message, ipfs, receipt, id): Promise<void> {
     alias: msg.payload.alias,
     created: msg.timestamp
   };
-  await db.queryAsync('INSERT INTO aliases SET ?', params);
+  await db.queryAsync(
+    'INSERT INTO aliases SET ? ON DUPLICATE KEY UPDATE id = VALUES(id), ipfs = VALUES(ipfs), created = VALUES(created)',
+    params
+  );
 }

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -1,30 +1,78 @@
 import { isExistingAlias } from '../../../src/helpers/alias';
 import db, { sequencerDB } from '../../../src/helpers/mysql';
+import { action, verify } from '../../../src/writer/alias';
 import { aliasesSqlFixtures } from '../../fixtures/alias';
 
-describe('alias', () => {
-  const seed = Date.now().toFixed(0);
+const cleanupFixtures = () => {
+  const tuples = aliasesSqlFixtures.map(() => '(?, ?)').join(', ');
+  const params = aliasesSqlFixtures.flatMap(a => [a.address, a.alias]);
+  return db.queryAsync(
+    `DELETE FROM snapshot_sequencer_test.aliases WHERE (address, alias) IN (${tuples})`,
+    params
+  );
+};
 
-  beforeAll(async () => {
-    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases');
+describe('alias', () => {
+  beforeEach(async () => {
+    await cleanupFixtures();
     await Promise.all(
-      aliasesSqlFixtures.map(alias => {
-        const values = {
-          ...alias,
-          ipfs: seed
-        };
-        return db.queryAsync('INSERT INTO snapshot_sequencer_test.aliases SET ?', values);
-      })
+      aliasesSqlFixtures.map(alias =>
+        db.queryAsync('INSERT INTO snapshot_sequencer_test.aliases SET ?', alias)
+      )
     );
   });
 
-  afterEach(async () => {
-    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases where ipfs = ?', seed);
-  });
-
   afterAll(async () => {
+    await cleanupFixtures();
     await db.endAsync();
     await sequencerDB.endAsync();
+  });
+
+  describe('verify()', () => {
+    it('should pass when alias pair already exists (allows renewal)', async () => {
+      const { address, alias } = aliasesSqlFixtures[0];
+      const msg = {
+        version: '0.1.4',
+        timestamp: Math.floor(Date.now() / 1000),
+        type: 'alias',
+        payload: { alias }
+      };
+
+      await expect(verify({ address, msg: JSON.stringify(msg) })).resolves.toBeTruthy();
+    });
+
+    it('should pass when alias does not exist', async () => {
+      const address = '0x0000000000000000000000000000000000000001';
+      const msg = {
+        version: '0.1.4',
+        timestamp: Math.floor(Date.now() / 1000),
+        type: 'alias',
+        payload: { alias: '0x0000000000000000000000000000000000000002' }
+      };
+
+      await expect(verify({ address, msg: JSON.stringify(msg) })).resolves.toBeTruthy();
+    });
+  });
+
+  describe('action()', () => {
+    it('should bump created date when re-submitting existing alias', async () => {
+      const { address, alias } = aliasesSqlFixtures[0];
+      const newTimestamp = Math.floor(Date.now() / 1000) + 1000;
+      const msg = {
+        version: '0.1.4',
+        timestamp: newTimestamp,
+        type: 'alias',
+        payload: { alias }
+      };
+
+      await action({ address, msg: JSON.stringify(msg) }, 'ipfs-new', '', 'new-id');
+
+      const [row] = await db.queryAsync(
+        'SELECT created FROM aliases WHERE address = ? AND alias = ?',
+        [address, alias]
+      );
+      expect(row.created).toBe(newTimestamp);
+    });
   });
 
   describe('isExistingAlias()', () => {

--- a/test/unit/writer/alias.test.ts
+++ b/test/unit/writer/alias.test.ts
@@ -2,7 +2,7 @@ import omit from 'lodash/omit';
 import * as writer from '../../../src/writer/alias';
 import input from '../../fixtures/writer-payload/alias.json';
 
-describe('writer/profile', () => {
+describe('writer/alias', () => {
   describe('verify()', () => {
     const msg = JSON.parse(input.msg);
     const invalidMsg = [


### PR DESCRIPTION
## Summary

Re-submitting an existing (address, alias) pair was failing with a MySQL duplicate key error. This was problematic for bots and agents that use fixed addresses, as they couldn't renew or extend an alias once created.

Now the same pair can be re-submitted at any time (whether active or expired), which resets the `created` timestamp and effectively renews the alias. Uses `ON DUPLICATE KEY UPDATE` to handle this at the database level.

## Changes

- 🔧 Changed `INSERT` to `INSERT ... ON DUPLICATE KEY UPDATE` in `action()` to refresh `id`, `ipfs`, and `created` on re-submission
- 🧪 Added integration tests for alias renewal and created timestamp bump
- 🧹 Fixed describe block name in unit test (`writer/profile` → `writer/alias`)

## Test plan

- [ ] Verify alias unit tests pass (`yarn test:unit`)
- [ ] Verify integration tests pass (`yarn test:integration`)
- [ ] Manually test re-submitting an existing alias pair succeeds and updates the `created` timestamp