### PR TITLE
fix: ensure alias can only be linked to a single address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 # Remove some common IDE working directories
 .idea
 .vscode
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ coverage
 # Remove some common IDE working directories
 .idea
 .vscode
-package-lock.json

--- a/src/writer/alias.ts
+++ b/src/writer/alias.ts
@@ -14,10 +14,11 @@ export async function verify(message): Promise<any> {
     return Promise.reject('alias cannot be the same as the address');
   }
 
-  const [existing] = await db.queryAsync('SELECT address FROM aliases WHERE alias = ? LIMIT 1', [
-    msg.payload.alias
-  ]);
-  if (existing && existing.address.toLowerCase() !== message.address.toLowerCase()) {
+  const [existing] = await db.queryAsync(
+    'SELECT address FROM aliases WHERE alias = ? AND address != ? LIMIT 1',
+    [msg.payload.alias, message.address]
+  );
+  if (existing) {
     return Promise.reject('alias is already linked to another address');
   }
 

--- a/src/writer/alias.ts
+++ b/src/writer/alias.ts
@@ -14,10 +14,9 @@ export async function verify(message): Promise<any> {
     return Promise.reject('alias cannot be the same as the address');
   }
 
-  const [existing] = await db.queryAsync(
-    'SELECT address FROM aliases WHERE alias = ? LIMIT 1',
-    [msg.payload.alias]
-  );
+  const [existing] = await db.queryAsync('SELECT address FROM aliases WHERE alias = ? LIMIT 1', [
+    msg.payload.alias
+  ]);
   if (existing && existing.address.toLowerCase() !== message.address.toLowerCase()) {
     return Promise.reject('alias is already linked to another address');
   }

--- a/src/writer/alias.ts
+++ b/src/writer/alias.ts
@@ -14,12 +14,16 @@ export async function verify(message): Promise<any> {
     return Promise.reject('alias cannot be the same as the address');
   }
 
-  const existing = await db.queryAsync(
-    'SELECT 1 FROM aliases WHERE address = ? AND alias = ? LIMIT 1',
-    [message.address, msg.payload.alias]
-  );
-  if (existing.length > 0) {
-    return Promise.reject('alias already exists');
+  const results = await db.queryAsync('SELECT address FROM aliases WHERE alias = ?', [
+    msg.payload.alias
+  ]);
+  for (const row of results) {
+    if (row.address === message.address) {
+      return Promise.reject('alias already exists');
+    }
+  }
+  if (results.length > 0) {
+    return Promise.reject('alias is already linked to another address');
   }
 
   return true;

--- a/src/writer/alias.ts
+++ b/src/writer/alias.ts
@@ -10,9 +10,18 @@ export async function verify(message): Promise<any> {
     log.warn(`[writer] Wrong alias format ${JSON.stringify(schemaIsValid)}`);
     return Promise.reject('wrong alias format');
   }
-  if (message.from === msg.payload.alias) {
+  if (message.address === msg.payload.alias) {
     return Promise.reject('alias cannot be the same as the address');
   }
+
+  const existing = await db.queryAsync(
+    'SELECT 1 FROM aliases WHERE address = ? AND alias = ? LIMIT 1',
+    [message.address, msg.payload.alias]
+  );
+  if (existing.length > 0) {
+    return Promise.reject('alias already exists');
+  }
+
   return true;
 }
 

--- a/src/writer/alias.ts
+++ b/src/writer/alias.ts
@@ -10,9 +10,10 @@ export async function verify(message): Promise<any> {
     log.warn(`[writer] Wrong alias format ${JSON.stringify(schemaIsValid)}`);
     return Promise.reject('wrong alias format');
   }
-  if (message.from === msg.payload.alias) {
+  if (message.address === msg.payload.alias) {
     return Promise.reject('alias cannot be the same as the address');
   }
+
   return true;
 }
 
@@ -25,5 +26,8 @@ export async function action(message, ipfs, receipt, id): Promise<void> {
     alias: msg.payload.alias,
     created: msg.timestamp
   };
-  await db.queryAsync('INSERT INTO aliases SET ?', params);
+  await db.queryAsync(
+    'INSERT INTO aliases SET ? ON DUPLICATE KEY UPDATE id = VALUES(id), ipfs = VALUES(ipfs), created = VALUES(created)',
+    params
+  );
 }

--- a/test/fixtures/alias.ts
+++ b/test/fixtures/alias.ts
@@ -10,7 +10,7 @@ export const aliasesSqlFixtures: Record<string, any>[] = [
     id: '2',
     ipfs: 'Qm...',
     address: '0x02a0a8f3b6097e7a6bd7649deb30715323072a159c0e6b71b689bd245c146cc0',
-    alias: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+    alias: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f5',
     created: Math.floor(Date.now() / 1000)
   },
   {

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -3,6 +3,13 @@ import db, { sequencerDB } from '../../../src/helpers/mysql';
 import { action, verify } from '../../../src/writer/alias';
 import { aliasesSqlFixtures } from '../../fixtures/alias';
 
+const buildAliasMsg = (alias: string, timestamp = Math.floor(Date.now() / 1000)) => ({
+  version: '0.1.4',
+  timestamp,
+  type: 'alias',
+  payload: { alias }
+});
+
 const cleanupFixtures = () => {
   const tuples = aliasesSqlFixtures.map(() => '(?, ?)').join(', ');
   const params = aliasesSqlFixtures.flatMap(a => [a.address, a.alias]);
@@ -31,12 +38,7 @@ describe('alias', () => {
   describe('verify()', () => {
     it('should pass when alias pair already exists (allows renewal)', async () => {
       const { address, alias } = aliasesSqlFixtures[0];
-      const msg = {
-        version: '0.1.4',
-        timestamp: Math.floor(Date.now() / 1000),
-        type: 'alias',
-        payload: { alias }
-      };
+      const msg = buildAliasMsg(alias);
 
       await expect(verify({ address, msg: JSON.stringify(msg) })).resolves.toBeTruthy();
     });
@@ -44,12 +46,7 @@ describe('alias', () => {
     it('should reject when alias is already linked to another address', async () => {
       const alias = aliasesSqlFixtures[0].alias;
       const differentAddress = '0x0000000000000000000000000000000000000099';
-      const msg = {
-        version: '0.1.4',
-        timestamp: Math.floor(Date.now() / 1000),
-        type: 'alias',
-        payload: { alias }
-      };
+      const msg = buildAliasMsg(alias);
 
       await expect(verify({ address: differentAddress, msg: JSON.stringify(msg) })).rejects.toMatch(
         'alias is already linked to another address'
@@ -58,12 +55,7 @@ describe('alias', () => {
 
     it('should pass when alias does not exist', async () => {
       const address = '0x0000000000000000000000000000000000000001';
-      const msg = {
-        version: '0.1.4',
-        timestamp: Math.floor(Date.now() / 1000),
-        type: 'alias',
-        payload: { alias: '0x0000000000000000000000000000000000000002' }
-      };
+      const msg = buildAliasMsg('0x0000000000000000000000000000000000000002');
 
       await expect(verify({ address, msg: JSON.stringify(msg) })).resolves.toBeTruthy();
     });
@@ -73,12 +65,7 @@ describe('alias', () => {
     it('should bump created date when re-submitting existing alias', async () => {
       const { address, alias } = aliasesSqlFixtures[0];
       const newTimestamp = Math.floor(Date.now() / 1000) + 1000;
-      const msg = {
-        version: '0.1.4',
-        timestamp: newTimestamp,
-        type: 'alias',
-        payload: { alias }
-      };
+      const msg = buildAliasMsg(alias, newTimestamp);
 
       await action({ address, msg: JSON.stringify(msg) }, 'ipfs-new', '', 'new-id');
 

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -1,30 +1,63 @@
 import { isExistingAlias } from '../../../src/helpers/alias';
 import db, { sequencerDB } from '../../../src/helpers/mysql';
+import { verify } from '../../../src/writer/alias';
 import { aliasesSqlFixtures } from '../../fixtures/alias';
 
 describe('alias', () => {
   const seed = Date.now().toFixed(0);
 
-  beforeAll(async () => {
-    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases');
+  beforeEach(async () => {
+    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases WHERE ipfs = ?', seed);
     await Promise.all(
       aliasesSqlFixtures.map(alias => {
-        const values = {
-          ...alias,
-          ipfs: seed
-        };
-        return db.queryAsync('INSERT INTO snapshot_sequencer_test.aliases SET ?', values);
+        const values = { ...alias, ipfs: seed };
+        return db.queryAsync(
+          'INSERT INTO snapshot_sequencer_test.aliases SET ? ON DUPLICATE KEY UPDATE ipfs = VALUES(ipfs), created = VALUES(created)',
+          values
+        );
       })
     );
   });
 
-  afterEach(async () => {
-    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases where ipfs = ?', seed);
-  });
-
   afterAll(async () => {
+    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases WHERE ipfs = ?', seed);
     await db.endAsync();
     await sequencerDB.endAsync();
+  });
+
+  describe('verify()', () => {
+    it('should reject when alias already exists', async () => {
+      const { address, alias } = aliasesSqlFixtures[0];
+      const msg = {
+        version: '0.1.4',
+        timestamp: Math.floor(Date.now() / 1000),
+        type: 'alias',
+        from: address,
+        payload: { alias }
+      };
+
+      await expect(
+        verify({ address, from: address, msg: JSON.stringify(msg) })
+      ).rejects.toMatch('alias already exists');
+    });
+
+    it('should pass when alias does not exist', async () => {
+      const msg = {
+        version: '0.1.4',
+        timestamp: Math.floor(Date.now() / 1000),
+        type: 'alias',
+        from: '0x0000000000000000000000000000000000000001',
+        payload: { alias: '0x0000000000000000000000000000000000000002' }
+      };
+
+      await expect(
+        verify({
+          address: '0x0000000000000000000000000000000000000001',
+          from: '0x0000000000000000000000000000000000000001',
+          msg: JSON.stringify(msg)
+        })
+      ).resolves.toBeTruthy();
+    });
   });
 
   describe('isExistingAlias()', () => {

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -51,9 +51,9 @@ describe('alias', () => {
         payload: { alias }
       };
 
-      await expect(
-        verify({ address: differentAddress, msg: JSON.stringify(msg) })
-      ).rejects.toMatch('alias is already linked to another address');
+      await expect(verify({ address: differentAddress, msg: JSON.stringify(msg) })).rejects.toMatch(
+        'alias is already linked to another address'
+      );
     });
 
     it('should pass when alias does not exist', async () => {

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -41,6 +41,22 @@ describe('alias', () => {
       ).rejects.toMatch('alias already exists');
     });
 
+    it('should reject when alias is already linked to another address', async () => {
+      const alias = aliasesSqlFixtures[0].alias;
+      const differentAddress = '0x0000000000000000000000000000000000000099';
+      const msg = {
+        version: '0.1.4',
+        timestamp: Math.floor(Date.now() / 1000),
+        type: 'alias',
+        from: differentAddress,
+        payload: { alias }
+      };
+
+      await expect(
+        verify({ address: differentAddress, from: differentAddress, msg: JSON.stringify(msg) })
+      ).rejects.toMatch('alias is already linked to another address');
+    });
+
     it('should pass when alias does not exist', async () => {
       const msg = {
         version: '0.1.4',

--- a/test/integration/helpers/alias.test.ts
+++ b/test/integration/helpers/alias.test.ts
@@ -1,30 +1,78 @@
 import { isExistingAlias } from '../../../src/helpers/alias';
 import db, { sequencerDB } from '../../../src/helpers/mysql';
+import { action, verify } from '../../../src/writer/alias';
 import { aliasesSqlFixtures } from '../../fixtures/alias';
 
-describe('alias', () => {
-  const seed = Date.now().toFixed(0);
+const cleanupFixtures = () => {
+  const tuples = aliasesSqlFixtures.map(() => '(?, ?)').join(', ');
+  const params = aliasesSqlFixtures.flatMap(a => [a.address, a.alias]);
+  return db.queryAsync(
+    `DELETE FROM snapshot_sequencer_test.aliases WHERE (address, alias) IN (${tuples})`,
+    params
+  );
+};
 
-  beforeAll(async () => {
-    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases');
+describe('alias', () => {
+  beforeEach(async () => {
+    await cleanupFixtures();
     await Promise.all(
-      aliasesSqlFixtures.map(alias => {
-        const values = {
-          ...alias,
-          ipfs: seed
-        };
-        return db.queryAsync('INSERT INTO snapshot_sequencer_test.aliases SET ?', values);
-      })
+      aliasesSqlFixtures.map(alias =>
+        db.queryAsync('INSERT INTO snapshot_sequencer_test.aliases SET ?', alias)
+      )
     );
   });
 
-  afterEach(async () => {
-    await db.queryAsync('DELETE from snapshot_sequencer_test.aliases where ipfs = ?', seed);
-  });
-
   afterAll(async () => {
+    await cleanupFixtures();
     await db.endAsync();
     await sequencerDB.endAsync();
+  });
+
+  describe('verify()', () => {
+    it('should pass when alias pair already exists (allows renewal)', async () => {
+      const { address, alias } = aliasesSqlFixtures[0];
+      const msg = {
+        version: '0.1.4',
+        timestamp: Math.floor(Date.now() / 1000),
+        type: 'alias',
+        payload: { alias }
+      };
+
+      await expect(verify({ address, msg: JSON.stringify(msg) })).resolves.toBeTruthy();
+    });
+
+    it('should pass when alias does not exist', async () => {
+      const address = '0x0000000000000000000000000000000000000001';
+      const msg = {
+        version: '0.1.4',
+        timestamp: Math.floor(Date.now() / 1000),
+        type: 'alias',
+        payload: { alias: '0x0000000000000000000000000000000000000002' }
+      };
+
+      await expect(verify({ address, msg: JSON.stringify(msg) })).resolves.toBeTruthy();
+    });
+  });
+
+  describe('action()', () => {
+    it('should bump created date when re-submitting existing alias', async () => {
+      const { address, alias } = aliasesSqlFixtures[0];
+      const newTimestamp = Math.floor(Date.now() / 1000) + 1000;
+      const msg = {
+        version: '0.1.4',
+        timestamp: newTimestamp,
+        type: 'alias',
+        payload: { alias }
+      };
+
+      await action({ address, msg: JSON.stringify(msg) }, 'ipfs-new', '', 'new-id');
+
+      const [row] = await db.queryAsync(
+        'SELECT created FROM aliases WHERE address = ? AND alias = ?',
+        [address, alias]
+      );
+      expect(row.created).toBe(newTimestamp);
+    });
   });
 
   describe('isExistingAlias()', () => {

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -139,6 +139,7 @@ CREATE TABLE aliases (
   alias VARCHAR(100) NOT NULL,
   created INT(11) NOT NULL,
   PRIMARY KEY (address, alias),
+  UNIQUE KEY alias (alias),
   INDEX ipfs (ipfs)
 );
 

--- a/test/unit/writer/alias.test.ts
+++ b/test/unit/writer/alias.test.ts
@@ -1,3 +1,7 @@
+jest.mock('../../../src/helpers/mysql', () => ({
+  default: { queryAsync: jest.fn().mockResolvedValue([]) }
+}));
+
 import omit from 'lodash/omit';
 import * as writer from '../../../src/writer/alias';
 import input from '../../fixtures/writer-payload/alias.json';

--- a/test/unit/writer/alias.test.ts
+++ b/test/unit/writer/alias.test.ts
@@ -2,7 +2,7 @@ import * as writer from '../../../src/writer/alias';
 import input from '../../fixtures/writer-payload/alias.json';
 import omit from 'lodash/omit';
 
-describe('writer/profile', () => {
+describe('writer/alias', () => {
   describe('verify()', () => {
     const msg = JSON.parse(input.msg);
     const invalidMsg = [

--- a/test/unit/writer/alias.test.ts
+++ b/test/unit/writer/alias.test.ts
@@ -1,14 +1,15 @@
-jest.mock('../../../src/helpers/mysql', () => ({
-  default: { queryAsync: jest.fn().mockResolvedValue([]) }
-}));
-
 import omit from 'lodash/omit';
+import db from '../../../src/helpers/mysql';
 import * as writer from '../../../src/writer/alias';
 import input from '../../fixtures/writer-payload/alias.json';
 
 describe('writer/alias', () => {
   describe('verify()', () => {
     const msg = JSON.parse(input.msg);
+
+    beforeEach(() => {
+      jest.spyOn(db, 'queryAsync').mockResolvedValue([]);
+    });
     const invalidMsg = [
       ['unknown field', { ...msg, payload: { ...msg.payload, title: 'title' } }],
       ['missing field', { msg, payload: omit(msg.payload, 'alias') }],

--- a/test/unit/writer/alias.test.ts
+++ b/test/unit/writer/alias.test.ts
@@ -2,7 +2,7 @@ import omit from 'lodash/omit';
 import * as writer from '../../../src/writer/alias';
 import input from '../../fixtures/writer-payload/alias.json';
 
-describe('writer/profile', () => {
+describe('writer/alias', () => {
   describe('verify()', () => {
     const msg = JSON.parse(input.msg);
     const invalidMsg = [


### PR DESCRIPTION
## Summary

An alias could previously be linked to multiple addresses, allowing different users to claim the same alias. This PR adds a server-side check in `verify()` to reject alias creation when the alias is already linked to a different address, while still allowing the same address to renew its existing alias.

## Changes

- ✅ `verify()`: rejects when alias is linked to a different address (single SQL query with `AND address != ?`)
- ✅ `action()`: uses `ON DUPLICATE KEY UPDATE` for renewals (from master via PR #629)
- ✅ Added `UNIQUE KEY` on `aliases.alias` in test schema
- ✅ Updated fixtures to avoid `UNIQUE KEY` collision
- ✅ Integration test for cross-address alias rejection
- ✅ Unit test with DB mock since `verify()` now queries the DB

## Database migration

Run the following on the production database to enforce uniqueness at the DB level:

```sql
ALTER TABLE aliases ADD UNIQUE KEY alias (alias);
```

## Test plan

- `yarn test:unit` — alias unit tests pass with mocked DB
- `yarn test:integration` — alias integration tests pass, including new cross-address rejection test
- `yarn test:e2e` — existing e2e tests unaffected