### PR TITLE
chore(tests): scope jest test discovery to project test directory

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@
  */
 
 export default {
+  roots: ['<rootDir>/test'],
   clearMocks: true,
   collectCoverage: true,
   collectCoverageFrom: ['./src/**'],


### PR DESCRIPTION
## Summary

Jest had no explicit `roots` configured, so it discovered and ran tests from `.claude/worktrees/` alongside the main `test/` directory. Both test sets inserted the same fixtures into the shared `snapshot_sequencer_test` database, causing `ER_DUP_ENTRY` failures across alias, actions, and ingestor integration tests (14 failures).

## Changes

- ✏️ Added `roots: ['<rootDir>/test']` to `jest.config.ts` to restrict test discovery to the project's own test directory

## Test plan

- Run `yarn test:integration` and confirm duplicate entry failures are resolved (14 failures → 1 unrelated failure in `unfollows.test.ts`)