### PR TITLE
fix: restrict delete-proposal alias to Starknet authors

### DIFF
--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -2,7 +2,7 @@ import db from './mysql';
 
 const DEFAULT_ALIAS_EXPIRY_DAYS = 30;
 
-const TYPES_EXECUTABLE_BY_ALIAS = [
+const TYPES_EXECUTABLE_BY_ALIAS: readonly string[] = [
   'follow',
   'unfollow',
   'subscribe',
@@ -15,9 +15,9 @@ const TYPES_EXECUTABLE_BY_ALIAS = [
   'proposal',
   'update-proposal',
   'flag-proposal'
-] as const;
+];
 
-const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = ['delete-proposal'] as const;
+const TYPES_EXECUTABLE_BY_STARKNET_ALIAS: readonly string[] = ['delete-proposal'];
 
 function isStarknetAddress(address: string): boolean {
   return /^0x[0-9a-fA-F]{64}$/.test(address);
@@ -45,8 +45,8 @@ export async function verifyAlias(type: string, body: any): Promise<void> {
   if (body.address === message.from) return;
 
   const allowed =
-    TYPES_EXECUTABLE_BY_ALIAS.includes(type as any) ||
-    (isStarknetAddress(message.from) && TYPES_EXECUTABLE_BY_STARKNET_ALIAS.includes(type as any));
+    TYPES_EXECUTABLE_BY_ALIAS.includes(type) ||
+    (isStarknetAddress(message.from) && TYPES_EXECUTABLE_BY_STARKNET_ALIAS.includes(type));
 
   if (!allowed) {
     return Promise.reject(`alias not allowed for the type: ${type}`);

--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -14,9 +14,14 @@ const TYPES_EXECUTABLE_BY_ALIAS = [
   'vote-string',
   'proposal',
   'update-proposal',
-  'delete-proposal',
   'flag-proposal'
 ] as const;
+
+const TYPES_EXECUTABLE_BY_STARKNET_ALIAS = ['delete-proposal'] as const;
+
+function isStarknetAddress(address: string): boolean {
+  return /^0x[0-9a-fA-F]{64}$/.test(address);
+}
 
 export async function isExistingAlias(
   address: string,
@@ -39,7 +44,11 @@ export async function verifyAlias(type: string, body: any): Promise<void> {
 
   if (body.address === message.from) return;
 
-  if (!TYPES_EXECUTABLE_BY_ALIAS.includes(type as any)) {
+  const allowed =
+    TYPES_EXECUTABLE_BY_ALIAS.includes(type as any) ||
+    (isStarknetAddress(message.from) && TYPES_EXECUTABLE_BY_STARKNET_ALIAS.includes(type as any));
+
+  if (!allowed) {
     return Promise.reject(`alias not allowed for the type: ${type}`);
   }
 

--- a/test/unit/helpers/alias.test.ts
+++ b/test/unit/helpers/alias.test.ts
@@ -1,11 +1,18 @@
 import { verifyAlias } from '../../../src/helpers/alias';
+import db from '../../../src/helpers/mysql';
 
 jest.mock('../../../src/helpers/mysql', () => ({
   __esModule: true,
   default: { queryAsync: jest.fn() }
 }));
 
+const mockedQueryAsync = db.queryAsync as jest.Mock;
+
 describe('verifyAlias()', () => {
+  beforeEach(() => {
+    mockedQueryAsync.mockReset();
+  });
+
   it('resolves when the sender is the creator', async () => {
     const body = { address: '0xabc', data: { message: { from: '0xabc' } } };
     await expect(verifyAlias('vote', body)).resolves.toBeUndefined();
@@ -22,5 +29,28 @@ describe('verifyAlias()', () => {
       data: { message: { from: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f4' } }
     };
     await expect(verifyAlias('delete-proposal', body)).rejects.toMatch('alias not allowed');
+  });
+
+  it('resolves delete-proposal when the author is a Starknet address with a valid alias', async () => {
+    const body = {
+      address: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+      data: {
+        message: {
+          from: '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+        }
+      }
+    };
+    mockedQueryAsync.mockResolvedValueOnce([{ 1: 1 }]);
+    await expect(verifyAlias('delete-proposal', body)).resolves.toBeUndefined();
+    expect(mockedQueryAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects with 'wrong alias' when the type is allowed but no alias row exists", async () => {
+    const body = {
+      address: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+      data: { message: { from: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f4' } }
+    };
+    mockedQueryAsync.mockResolvedValueOnce([]);
+    await expect(verifyAlias('vote', body)).rejects.toMatch('wrong alias');
   });
 });

--- a/test/unit/helpers/alias.test.ts
+++ b/test/unit/helpers/alias.test.ts
@@ -15,4 +15,12 @@ describe('verifyAlias()', () => {
     const body = { address: '0xaaa', data: { message: { from: '0xbbb' } } };
     await expect(verifyAlias('settings', body)).rejects.toMatch('alias not allowed');
   });
+
+  it('rejects delete-proposal when the author is an EVM address', async () => {
+    const body = {
+      address: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+      data: { message: { from: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f4' } }
+    };
+    await expect(verifyAlias('delete-proposal', body)).rejects.toMatch('alias not allowed');
+  });
 });


### PR DESCRIPTION
## Summary
- Drop `delete-proposal` from `TYPES_EXECUTABLE_BY_ALIAS`.
- Gate it behind a Starknet author check via a small `TYPES_EXECUTABLE_BY_STARKNET_ALIAS = ['delete-proposal']` list and reintroduce `isStarknetAddress`.
- EVM aliases can still vote / propose / update-proposal / flag-proposal — only deletion is restricted.

Follows up on #634, which inadvertently promoted `delete-proposal` to EVM aliases when collapsing the type buckets. Deletion is destructive and irrecoverable, so the pre-refactor Starknet-only behavior is the safer default until alias-typed signers (user vs. agent, per snapshot-labs/workflow#793) land.

## Test plan
- [x] `yarn lint`
- [x] Added unit case: `delete-proposal` from an EVM alias rejects with `alias not allowed for the type: delete-proposal`.
- [ ] `yarn test` (CI)
- [ ] Manual: EVM alias signing `delete-proposal` for an EVM author → rejected.
- [ ] Manual: Starknet alias signing `delete-proposal` for a Starknet author with a valid alias row → accepted.
- [ ] Manual: EVM alias signing `vote` / `proposal` / `update-proposal` / `flag-proposal` → still accepted (regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)