### PR TITLE
chore+fix: add Arbitrum onchain space to Tally statement importer

### DIFF
--- a/src/lib/importer/statement/provider/tally.ts
+++ b/src/lib/importer/statement/provider/tally.ts
@@ -49,6 +49,7 @@ const ORGANIZATION_QUERY = {
 export default class Tally extends Provider {
   static readonly MAPPING = {
     's:arbitrumfoundation.eth': 'arbitrum',
+    'arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4': 'arbitrum',
     's:uniswapgovernance.eth': 'uniswap',
     's:dopedao.eth': 'dopewars',
     's:opcollective.eth': 'optimism',
@@ -108,7 +109,7 @@ export default class Tally extends Provider {
 
       const _delegates: Delegate[] = [];
       results.delegates.nodes.forEach((node: any) => {
-        const statement = node.statement.statement.trim();
+        const statement = node.statement?.statement?.trim();
 
         if (!statement) return;
 


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/workflow/issues/804

## What

Two small changes to the Tally statement importer:

1. **Add Arbitrum onchain space to the MAPPING** — the importer previously only knew about the legacy offchain Snapshot space (`s:arbitrumfoundation.eth`). This adds the Arbitrum Core Governor SX space (`arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4`) so that Tally delegate statements get stored with the correct `network` and `space` values that the SX UI queries.

2. **Fix crash when Tally returns `null` for a delegate's statement** — Tally's API sometimes returns `statement: null` instead of `statement: { statement: "" }` for delegates who haven't written a statement. The previous code assumed the object was always present and crashed with `Cannot read properties of null`. Changed to optional chaining (`?.`) so those delegates are safely skipped.

## How to run

```bash
TALLY_API_KEY=<your-key> yarn ts-node scripts/import-statements.ts \
  --providers tally \
  --spaces arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4
```

## Test plan

- [x] Script fetches Arbitrum delegates from Tally and writes rows with `network='arb1'`, `space='0x789…'`, `source='tally'`
- [x] Delegates with `statement: null` are skipped without crashing
- [x] No changes needed on the SX UI side — statement loading already queries by `(network, space)` and works for onchain spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)