### PR TITLE
fix: skip Sentry capture for expected client errors

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,3 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import express, { NextFunction, Request, Response } from 'express';
 import duplicateRequestPreventor, { cleanup } from './helpers/duplicateRequestPreventor';
 import log from './helpers/log';
@@ -6,7 +5,7 @@ import { flagEntity } from './helpers/moderation';
 import poke from './helpers/poke';
 import relayer from './helpers/relayer';
 import serve from './helpers/requestDeduplicator';
-import { sendError, verifyAuth } from './helpers/utils';
+import { captureException, sendError, verifyAuth } from './helpers/utils';
 import typedData from './ingestor';
 import { updateProposalAndVotes } from './scores';
 import { name, version } from '../package.json';
@@ -52,7 +51,7 @@ router.get('/scores/:proposalId', async (req, res) => {
     const result = await serve(proposalId, updateProposalAndVotes, [proposalId]);
     return res.json({ result });
   } catch (e) {
-    capture(e);
+    captureException(e);
     log.warn(`[api] updateProposalAndVotes() failed ${proposalId}, ${JSON.stringify(e)}`);
     return res.json({ error: 'failed', message: e });
   }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -239,8 +239,22 @@ export const getQuorum = async (options: any, network: string, blockTag: number)
   }
 };
 
+const EXPECTED_CLIENT_ERROR_MESSAGES = new Set(['unauthorized']);
+
+export function isExpectedClientError(e: any): boolean {
+  const message = e instanceof Error ? e.message : typeof e === 'string' ? e : '';
+  return EXPECTED_CLIENT_ERROR_MESSAGES.has(message);
+}
+
+export function captureException(e: any, context?: any) {
+  if (isExpectedClientError(e)) return;
+
+  capture(e, context);
+}
+
 export function captureError(e: any, context?: any, ignoredErrorCodes?: number[]) {
   if (ignoredErrorCodes?.includes(e.code)) return;
+  if (isExpectedClientError(e)) return;
 
   capture(e, context);
 }

--- a/test/unit/helpers/utils.test.ts
+++ b/test/unit/helpers/utils.test.ts
@@ -1,0 +1,65 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { captureError, captureException, isExpectedClientError } from '../../../src/helpers/utils';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+const mockedCapture = capture as jest.Mock;
+
+describe('utils.ts', () => {
+  describe('isExpectedClientError', () => {
+    it.each([
+      ['Error("unauthorized")', new Error('unauthorized')],
+      ['plain string "unauthorized"', 'unauthorized']
+    ])('returns true for %s', (_label, value) => {
+      expect(isExpectedClientError(value)).toBe(true);
+    });
+
+    it.each([
+      ['random Error', new Error('something went wrong')],
+      ['unrelated string', 'failed'],
+      ['undefined', undefined],
+      ['null', null],
+      ['number', 42]
+    ])('returns false for %s', (_label, value) => {
+      expect(isExpectedClientError(value)).toBe(false);
+    });
+  });
+
+  describe('captureException', () => {
+    beforeEach(() => mockedCapture.mockClear());
+
+    it('skips capture for expected client errors', () => {
+      captureException(new Error('unauthorized'));
+      captureException('unauthorized');
+      expect(mockedCapture).not.toHaveBeenCalled();
+    });
+
+    it('forwards unexpected errors to capture', () => {
+      const err = new Error('boom');
+      captureException(err, { ctx: 1 });
+      expect(mockedCapture).toHaveBeenCalledWith(err, { ctx: 1 });
+    });
+  });
+
+  describe('captureError', () => {
+    beforeEach(() => mockedCapture.mockClear());
+
+    it('skips capture when error code is in the ignored list', () => {
+      captureError({ code: 504, message: 'gateway timeout' }, undefined, [504]);
+      expect(mockedCapture).not.toHaveBeenCalled();
+    });
+
+    it('skips capture for expected client errors', () => {
+      captureError(new Error('unauthorized'));
+      expect(mockedCapture).not.toHaveBeenCalled();
+    });
+
+    it('forwards everything else to capture', () => {
+      const err = new Error('boom');
+      captureError(err, { ctx: 1 }, [504]);
+      expect(mockedCapture).toHaveBeenCalledWith(err, { ctx: 1 });
+    });
+  });
+});


### PR DESCRIPTION
Stop logging `unauthorized` (and other expected 4xx) client errors to Sentry.

## Summary
- The score-api returns `unauthorized` for client-side auth failures, which propagated through `snapshot.utils.validate` / `getVp` / `getScores` / `updateProposalAndVotes` and were captured to Sentry, generating ~25k events across [SEQUENCER-26](https://snapshot-labs.sentry.io/issues/SNAPSHOT-SEQUENCER-26) + [-37](https://snapshot-labs.sentry.io/issues/SNAPSHOT-SEQUENCER-37) + [-38](https://snapshot-labs.sentry.io/issues/SNAPSHOT-SEQUENCER-38) with zero actionable signal.

## Changes
- \U0001F195 `isExpectedClientError` + `captureException` helpers in `src/helpers/utils.ts`
- \U0001F50A `captureError` now also skips expected client errors
- \U0001F501 `/scores/:proposalId` capture routed through `captureException`
- \U0001F9EA Unit tests for the new helpers and `captureError` filter

## Test plan
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn test:unit` — 12 suites, 104 passing (incl. new tests)
- [ ] CI passes