### PR TITLE
fix: ignore "unauthorized" errors in Sentry

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,3 +1,3 @@
 import { initLogger } from '@snapshot-labs/snapshot-sentry';
 
-initLogger();
+initLogger({ ignoreErrors: ['unauthorized'] });


### PR DESCRIPTION
Stop logging `unauthorized` client errors to Sentry by using the new `ignoreErrors` option in snapshot-sentry.

## Summary
- The score-api returns `unauthorized` for client-side auth failures, which propagated through `snapshot.utils.validate` / `getVp` / `getScores` / `updateProposalAndVotes` and were captured to Sentry, generating ~25k events across [SEQUENCER-26](https://snapshot-labs.sentry.io/issues/SNAPSHOT-SEQUENCER-26) + [-37](https://snapshot-labs.sentry.io/issues/SNAPSHOT-SEQUENCER-37) + [-38](https://snapshot-labs.sentry.io/issues/SNAPSHOT-SEQUENCER-38) with no actionable signal.
- Filtering is handled at the SDK level via Sentry's built-in `ignoreErrors` option, plumbed through snapshot-sentry's `initLogger` (snapshot-labs/snapshot-sentry#18). No service-level capture wrapper needed.

## Changes
- `initLogger({ ignoreErrors: ['unauthorized'] })` in `src/index.ts` — single-line change

## Stack / merge order
1. snapshot-labs/snapshot-sentry#17 — base v2 (Sentry v10 upgrade)
2. snapshot-labs/snapshot-sentry#18 — adds `ignoreErrors` option (must merge into upgrade-sentry-v10 before this PR)
3. #642 — bump sequencer to snapshot-sentry v2
4. **this PR** — start using `ignoreErrors`

This PR replaces #641, which carried per-repo capture wrappers — those become unnecessary once the upstream filter ships.

## Test plan
- [x] `bun run lint` clean
- [ ] CI passes (after #18 merges into upgrade-sentry-v10)